### PR TITLE
Add initial draft of instructions to contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,30 @@
+# Contribution guidelines for the OpenPBTA-analysis
+
+## Issues
+
+The best place to initially engage with the project is likely to be via creation of new issues or participation in existing issues.
+We use issues to address difficulties interacting with the data, limitations of the current data processing approaches, or other roadblocks.
+We also use issues for discussion of analyses.
+Participants who wish to perform an analysis of the data as part of this effort should either identify an existing, planned analysis that they wish to tackle or propose a new one.
+
+## Pull requests
+
+Contributions to the analysis repository operate on a pull request model.
+We expect participants to actively review pull requests, with a particular focus on pull requests that include analyses within their areas of expertise.
+
+## Authorship
+
+The ultimate goal of this is effort is to describe the results of our analyses in a manuscript.
+We will use the [ICMJE Guidelines](http://www.icmje.org/recommendations/browse/roles-and-responsibilities/defining-the-role-of-authors-and-contributors.html).
+We expect authors to contribute to the overall design of the project by participating in issues, to contribute analyses via filing pull requests that integrate analyses into this repository, to contribute to the text by contributing sections and/or revisions to sections through pull requests on the [OpenPBTA-manuscript repository](https://github.com/AlexsLemonade/OpenPBTA-manuscript/).
+It is important to note that, for authorship, these should be substantial intellectual contributions.
+
+## Peer review
+
+All pull requests will undergo peer review.
+Participants in this project should review pull requests, which can be done using [GitHub's review interface](https://help.github.com/articles/about-pull-request-reviews/ "GitHub: about pull request reviews").
+They should suggest modifications or, potentially, directly edit the pull request to make suggested changes.
+As a reviewer, it's helpful to note the type of review you performed: did you look over the source code, did you run the source code, did you look at and interpret the results or a combination of these?
+
+Before a repository maintainer merges a pull request, there must be at least one affirmative review.
+If there is any unaddressed criticism or disapproval, a repository maintainer will determine how to proceed and may wait for additional feedback.


### PR DESCRIPTION
It can be helpful to provide instructions to aid prospective contributors as they engage with the project.