### PR TITLE
Draft of instructions for planned analyses

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,18 @@ The analysis repository for the Open Pediatric Brain Tumor Atlas (OpenPBTA) Proj
 
 ## How to Participate
 
-### Existing Planned Analyses
+### Planned Analyses
+
+There are certain analyses that we have planned or that others have proposed, but which nobody is currently in charge of completing.
+Check the existing [issues](https://github.com/AlexsLemonade/OpenPBTA-analysis/issues) to identify these.
+We have tagged a [subset of these with the label "good first issue"](https://github.com/AlexsLemonade/OpenPBTA-analysis/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
+These "good first issues" are ones that have a limited scope, that can be done with the software already present on the Docker container, and that we expect to have few dependencies with other issues.
+If you would like to take on these or any other existing planned analysis, please comment on the issue noting your interest in tackling the issue in question.
+Ask clarifying questions to understand the current scope and goals.
+Then propose a potential solution.
+If the solution aligns with the goals, we will ask you to go ahead and start to implement the solution.
+You should provide updates to your progress in the issue.
+When you file a pull request with your solution, you should note that it closes the issue in question.
 
 ### Proposing a New Analysis
 


### PR DESCRIPTION
The analyses that are already planned but not currently claimed or implemented provide a good opportunity for someone to engage with the project. This describes how to engage with those, and also commits us to keeping some issues tagged as good for first time contributors based on certain rules.