### PR TITLE
Add and ignore scratch folder

### DIFF
--- a/scratch/.gitignore
+++ b/scratch/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
Here, I'm adding a scratch folder and ignoring its contents. This is consistent with what I would expect based on the following from the README:
> Intermediate files that are useful within the processing steps but that do not represent final results should be placed in `../../scratch/`. It is safe to assume that files placed in `../../scratch` will be available to all analyses within the same folder. It is not safe to assume that files placed in `../../scratch` will be available from analyses in a different folder.

and from the Output section:

> Files that are intermediate, which means that they are useful within an analysis but do not provide outputs intended for tables, figures, or supplementary tables or figures of the OpenPBTA-manuscript, should be placed in `../../scratch`.