### PR TITLE
Add relevant literature section

### DIFF
--- a/.github/ISSUE_TEMPLATE/propose-an-analysis.md
+++ b/.github/ISSUE_TEMPLATE/propose-an-analysis.md
@@ -24,3 +24,7 @@ _What input data will you use for this analysis?_
 #### Proposed timeline
 
 _What is the timeline for the analysis?_
+
+#### Relevant literature
+
+_If there is relevant scientific literature, put links to those items here._


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

#### Purpose/implementation

This PR adds a `#### Relevant literature` section of the Propose an analysis issue template.

#### Issue

N/A, I originally intended to include a section for links to relevant literature in the issue template for proposing an analysis. I believe this could be helpful for focusing discussion and it's been happening somewhat organically on the `Planned Analysis` issues.
