### PR TITLE
Fix: volume in run_in_ci.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM rocker/tidyverse:3.6.0
 MAINTAINER ccdl@alexslemonade.org
+WORKDIR /rocker-build/
 
 RUN apt-get update && apt-get install -y --no-install-recommends apt-utils
 RUN apt-get install dialog apt-utils -y
@@ -7,5 +8,3 @@ RUN apt-get install dialog apt-utils -y
 #### Please install your dependencies here
 #### Add a comment to indicate what analysis it is required for
 
-RUN groupadd user && useradd --create-home --home-dir /home/user -g user user
-WORKDIR /home/user

--- a/scripts/run_in_ci.sh
+++ b/scripts/run_in_ci.sh
@@ -32,6 +32,5 @@ if [ $finished != 0 ] && [ $attempts -ge 3 ]; then
 fi
 
 docker run \
-       --user user \
-       --volume "$(pwd)/data":/home/user/data \
+       --volume "$(pwd)":/rocker-build/ \
        -it "open-pbta" "$@"


### PR DESCRIPTION
This workflow failed because it couldn't find the files: https://circleci.com/gh/AlexsLemonade/OpenPBTA-analysis/127?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

I think these changes may remedy that because of the following functional tests:

* `./scripts/run_in_ci.sh ls` returns the contents of my current working directory (the top directory of the repository).
* If I start running: `./scripts/run_in_ci.sh Rscript -e "rmarkdown::render('analyses/create-subset-files/01-create_subset_files.Rmd',  clean = TRUE)"`, it gives me output consistent with running that file from the command line (e.g., starts installing packages).

I can confirm that image built from this changed Dockerfile still allows you to access the RStudio server via method in the README.
