### PR TITLE
Tweak to download in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
 
       - run:
           name: Data Download
-          command: URL=https://open-pbta.s3.amazonaws.com/data RELEASE=testing ./download-data.sh
+          command: BASEURL=https://open-pbta.s3.amazonaws.com/data REL=testing ./download-data.sh
 
       - run:
           name: List Data Directory Contents

--- a/download-data.sh
+++ b/download-data.sh
@@ -3,8 +3,8 @@ set -e
 set -o pipefail
 
 # Use the OpenPBTA bucket as the default.
-URL=${URL:-https://s3.amazonaws.com/kf-openaccess-us-east-1-prd-pbta/data}
-RELEASE=${RELEASE:-release-v2-20190809}
+URL=${BASEURL:-https://s3.amazonaws.com/kf-openaccess-us-east-1-prd-pbta/data}
+RELEASE=${REL:-release-v2-20190809}
 
 # The md5sum file provides our single point of truth for which files are in a release.
 curl --create-dirs $URL/$RELEASE/md5sum.txt -o data/$RELEASE/md5sum.txt -z data/$RELEASE/md5sum.txt


### PR DESCRIPTION
I don't think we were getting the subset files as intended because `ls data/testing` included `release-notes.md` which are not in the subset file bucket. Trying this out.