### PR TITLE
Add 'Size and composition of pull requests' to contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,7 @@ Commit and push your changes to this branch.
 You will then be able to file a pull request from this branch: https://help.github.com/en/articles/creating-a-pull-request-from-a-fork
 4. Once your pull request is approved and merged by the project maintainers, it's time to keep the `master` branch of your fork up-to-date with the `master` branch of this repository by following this process: https://help.github.com/en/articles/syncing-a-fork.
 Here's a typical series of steps for performing that:
+
 ```
 # fetch the changes from the AlexsLemonade repository
 git fetch upstream
@@ -39,7 +40,69 @@ git merge upstream/master
 # push the changes to your master branch to the remote repository
 git push
 ```
+
 You do not want to commit changes to your `master` branch, any changes to your `master` branch should come from the upstream `master` branch.
+
+### Size and composition of pull requests
+
+An ideal pull request is small enough for reviewers to review the code in detail and focused on a single area or, if adding a new file entirely, a single file.
+Implementing an analysis will often require more than one notebook or script to be added to the repository.
+In these cases, it is desirable to submit _multiple pull requests_ for an analysis rather than a single, large pull request when an analysis is completed.
+This both facilitates scientific discussion and reduces the burden on reviewers (see [Peer review](#peer-review)).
+
+As the author of a pull request, consider what reviewers who have not been working on the analysis need to know to perform an effective review. 
+We've put together a [pull request template](https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/.github/PULL_REQUEST_TEMPLATE.md) to help.
+
+#### Creating stacked pull requests
+
+If you find that the changes on your branch include multiple files and a large number of lines of code have been changed, you may want to file a [**draft pull request**](https://help.github.com/en/articles/about-pull-requests#draft-pull-requests) to get feedback on splitting up the changes into multiple pull requests. You can read more about how to split up pull requests [here](https://graysonkoonce.com/stacked-pull-requests-keeping-github-diffs-small/) and in the ["4 Git strategies for Pull Requests splitting" section](https://www.thedroidsonroids.com/blog/splitting-pull-request#4-git-strategies-for-pull-requests-splitting) of this article. We include a simple example, adapted from the first link, below.
+
+Say I have a new analysis on a branch called `new-analysis` that includes three scripts: `01-first-script.R`, `02-second-script.R`, and `03-third-script.R`.
+All three scripts have been committed to the `new-analysis` branch.
+To file three pull requests, one for each script, I could take the following approach:
+
+**Add the first script to its own branch `new-analysis-first`.**
+
+We're creating the new branch with all the changes from `new-analysis` unstaged.
+
+```sh
+git checkout -b new-analysis-first new-analysis
+git reset master
+```
+
+Now we're ready to add, commit, and push `01-first-script.R`.
+
+```sh
+# add the first script
+git add analyses/new-analyses/01-first-script.R
+
+# stash all other changes (e.g., the second and third script)
+git stash --include-untracked --keep-index
+
+# commit + push the changes to the first script
+git commit -m "Add first script for new analysis"
+git push origin new-analysis-first
+```
+
+**We're then ready to file a pull request from the `new-analysis-first` branch.**
+
+To get a pull request ready for `02-second-script.R`, we'd do the following:
+
+```sh
+# create a new branch for this purpose
+git checkout -b new-analysis-second
+
+# pop the stash that contains the second and third scripts
+git stash pop
+
+# add, stash, commit, push
+git add analyses/new-analyses/02-second-script.R
+git stash --include-untracked --keep-index
+git commit -m "Add second script for new analysis"
+git push origin new-analysis-second
+```
+
+These steps can be repeated for `03-third-script.R`.
 
 ## Authorship
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,8 @@ Participants who wish to perform an analysis of the data as part of this effort 
 Contributions to the analysis repository operate on a pull request model.
 We expect participants to actively review pull requests, with a particular focus on pull requests that include analyses within their areas of expertise.
 
+_If you are new to git and GitHub, check out [this Hello World guide](https://guides.github.com/activities/hello-world/) and [the GitHub documentation for reviewing changes in pull requests](https://help.github.com/en/articles/reviewing-changes-in-pull-requests)._
+
 ### Filing a pull request from your own branch
 
 Here, we include a _typical_ workflow for filing a pull request to contribute to this project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,17 +47,19 @@ You do not want to commit changes to your `master` branch, any changes to your `
 
 An ideal pull request is small enough for reviewers to review the code in detail and focused on a single area or, if adding a new file entirely, a single file.
 Implementing an analysis will often require more than one notebook or script to be added to the repository.
-In these cases, it is desirable to submit _multiple pull requests_ for an analysis rather than a single, large pull request when an analysis is completed.
-This both facilitates scientific discussion and reduces the burden on reviewers (see [Peer review](#peer-review)).
+It is best to submit _multiple pull requests_ for these analyses rather than a single, large pull request when an analysis is completed.
+This facilitates scientific discussion and reduces the burden on reviewers (see [Peer review](#peer-review)).
 
 As the author of a pull request, consider what reviewers who have not been working on the analysis need to know to perform an effective review. 
 We've put together a [pull request template](https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/.github/PULL_REQUEST_TEMPLATE.md) to help.
 
 #### Creating stacked pull requests
 
-If you find that the changes on your branch include multiple files and a large number of lines of code have been changed, you may want to file a [**draft pull request**](https://help.github.com/en/articles/about-pull-requests#draft-pull-requests) to get feedback on splitting up the changes into multiple pull requests. You can read more about how to split up pull requests [here](https://graysonkoonce.com/stacked-pull-requests-keeping-github-diffs-small/) and in the ["4 Git strategies for Pull Requests splitting" section](https://www.thedroidsonroids.com/blog/splitting-pull-request#4-git-strategies-for-pull-requests-splitting) of this article. We include a simple example, adapted from the first link, below.
+If you find that the changes on your branch include multiple files and a large number of lines of code have been changed, you may want to file a [**draft pull request**](https://help.github.com/en/articles/about-pull-requests#draft-pull-requests) to get feedback on splitting up the changes into multiple pull requests.
+You can read more about how to split up pull requests [here](https://graysonkoonce.com/stacked-pull-requests-keeping-github-diffs-small/) and in the ["4 Git strategies for Pull Requests splitting" section](https://www.thedroidsonroids.com/blog/splitting-pull-request#4-git-strategies-for-pull-requests-splitting) of this article.
+We include a simple example, adapted from the first link, below.
 
-Say I have a new analysis on a branch called `new-analysis` that includes three scripts: `01-first-script.R`, `02-second-script.R`, and `03-third-script.R`.
+I have a new analysis on a branch called `new-analysis` that includes three scripts: `01-first-script.R`, `02-second-script.R`, and `03-third-script.R`.
 All three scripts have been committed to the `new-analysis` branch.
 To file three pull requests, one for each script, I could take the following approach:
 


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

#### Purpose/implementation

In #77, it is _implied_ that an analysis that requires multiple scripts or notebooks will be added via multiple pull requests (e.g., one file at a time). That is not noted anywhere and we should make that easier for folks.

Here I'm adding a section about the size and composition of pull requests to `CONTRIBUTING.md`. It is my intention to link to the pull request section of `CONTRIBUTING.md` when I implement the changes to satisfy #77.

I think it'd be best to link to this section in [**Implementing an analysis**](https://github.com/AlexsLemonade/OpenPBTA-analysis#implementing-an-analysis) as well. That will be a separate PR.

#### Issue

This is related to but does not directly address #77.

#### Directions for reviewers

The `Creating stacked pull requests` directions could use an extra pair of eyes. Are they correct? Is this typically how you approach this @cansav09 and @cbethell ?
