### PR TITLE
Yuankun/update v4 release

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -1,20 +1,21 @@
 # release notes
 ## current release
-### release-v3-20190829
-- release date: 2019-08-29
+### release-v4-20190909
+- release date: 2019-09-10
 - status: available
 - changes:
-  - Arriba fusions run with https://github.com/FusionAnnotator/CTAT_HumanFusionLib/wiki#red-herrings-fusion-pairs-that-may-not-be-relevant-to-cancer-and-potential-false-positives to match STAR-fusion results
-  - Clinical data sheet, added information for:
-    - germline_sex_estimate
-    - overall survival (days)
-    - overall survival status (living/deceased)
-    - RNA_library type
-    - edited previous sex variable to be reported_gender
+  - [Clinical V4](https://github.com/AlexsLemonade/OpenPBTA-analysis/issues/95):
+    - De-duplicated `BS_6DCSD5Y6` in the clinical file by removing row with wrong age
+    - Added units to `age_at_diagnosis` column (age_at_diagnosis_days)
+  - [new RSEM file](https://github.com/AlexsLemonade/OpenPBTA-analysis/issues/93):
+    - Remove QC-failed samples from V3 RSEM. 
+    - Add `BS_XM1AHBDJ` which should be included, but was missing from the V3 RSEM
+  - [new LUMPY file](https://github.com/AlexsLemonade/OpenPBTA-analysis/issues/97):
+    - Add data for 628 more subjects which was missing from V3 LUMPY
 - folder structure:
 ```
 data
-└── release-v3-20190829
+└── release-v4-20190909
     ├── CHANGELOG.md
     ├── md5sum.txt
     ├── pbta-cnv-cnvkit.seg.gz
@@ -32,6 +33,19 @@ data
 ```
 
 ## archived release
+### release-v3-20190829
+- release date: 2019-08-29
+- status: available
+- changes:
+  - Arriba fusions run with https://github.com/FusionAnnotator/CTAT_HumanFusionLib/wiki#red-herrings-fusion-pairs-that-may-not-be-relevant-to-cancer-and-potential-false-positives to match STAR-fusion results
+  - Clinical data sheet, added information for:
+    - germline_sex_estimate
+    - overall survival (days)
+    - overall survival status (living/deceased)
+    - RNA_library type
+    - edited previous sex variable to be reported_gender
+- folder structure: same to `release-v4-20190909`
+
 ### release-v2-20190809
 - release date: 2019-08-09
 - status: available

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -1,5 +1,37 @@
 # release notes
 ## current release
+### release-v3-20190829
+- release date: 2019-08-29
+- status: available
+- changes:
+  - Arriba fusions run with https://github.com/FusionAnnotator/CTAT_HumanFusionLib/wiki#red-herrings-fusion-pairs-that-may-not-be-relevant-to-cancer-and-potential-false-positives to match STAR-fusion results
+  - Clinical data sheet, added information for:
+    - germline_sex_estimate
+    - overall survival (days)
+    - overall survival status (living/deceased)
+    - RNA_library type
+    - edited previous sex variable to be reported_gender
+- folder structure:
+```
+data
+└── release-v3-20190829
+    ├── CHANGELOG.md
+    ├── md5sum.txt
+    ├── pbta-cnv-cnvkit.seg.gz
+    ├── pbta-cnv-controlfreec.seg.gz
+    ├── pbta-fusion-arriba.tsv.gz
+    ├── pbta-fusion-starfusion.tsv.gz
+    ├── pbta-gene-expression-kallisto.rds
+    ├── pbta-gene-expression-rsem.fpkm.rds
+    ├── pbta-histologies.tsv
+    ├── pbta-snv-mutect2.vep.maf.gz
+    ├── pbta-snv-strelka2.vep.maf.gz
+    ├── pbta-sv-lumpy.tsv.gz
+    ├── pbta-sv-manta.tsv.gz
+    └── README.md
+```
+
+## archived release
 ### release-v2-20190809
 - release date: 2019-08-09
 - status: available
@@ -37,7 +69,7 @@ data
     ├── pbta-sv-manta.tsv.gz
     └── README.md
 ```
-## archived release
+
 ### release-v1-20190730
 - release date: 2019-07-30
 - status: not-available as it contains consent/qc failed samples

--- a/download-data.sh
+++ b/download-data.sh
@@ -4,7 +4,7 @@ set -o pipefail
 
 # Use the OpenPBTA bucket as the default.
 URL=${URL:-https://s3.amazonaws.com/kf-openaccess-us-east-1-prd-pbta/data}
-RELEASE=${RELEASE:-release-v3-20190829}
+RELEASE=${RELEASE:-release-v4-20190909}
 
 # The md5sum file provides our single point of truth for which files are in a release.
 curl --create-dirs $URL/$RELEASE/md5sum.txt -o data/$RELEASE/md5sum.txt -z data/$RELEASE/md5sum.txt

--- a/download-data.sh
+++ b/download-data.sh
@@ -4,7 +4,7 @@ set -o pipefail
 
 # Use the OpenPBTA bucket as the default.
 URL=${URL:-https://s3.amazonaws.com/kf-openaccess-us-east-1-prd-pbta/data}
-RELEASE=${RELEASE:-release-v2-20190809}
+RELEASE=${RELEASE:-release-v3-20190829}
 
 # The md5sum file provides our single point of truth for which files are in a release.
 curl --create-dirs $URL/$RELEASE/md5sum.txt -o data/$RELEASE/md5sum.txt -z data/$RELEASE/md5sum.txt


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

#### Purpose/implementation

data release updates for v4

- changes:
  - [Clinical V4](https://github.com/AlexsLemonade/OpenPBTA-analysis/issues/95):
    - De-duplicated `BS_6DCSD5Y6` in the clinical file by removing row with wrong age
    - Added units to `age_at_diagnosis` column (age_at_diagnosis_days)
  - [new RSEM file](https://github.com/AlexsLemonade/OpenPBTA-analysis/issues/93):
    - Remove QC-failed samples from V3 RSEM. 
    - Add `BS_XM1AHBDJ` which should be included, but was missing from the V3 RSEM
  - [new LUMPY file](https://github.com/AlexsLemonade/OpenPBTA-analysis/issues/97):
    - Add data for 628 more subjects which was missing from V3 LUMPY

#### Issue


#### Directions for reviewers

changed on release notes and download script. file content updated for `pbta-gene-expression-rsem.fpkm.rds`, `pbta-histologies.tsv`, `pbta-sv-lumpy.tsv.gz` and `md5sum.txt`.

#### Results


#### Docker and continuous integration
