### PR TITLE
Add cloning, remote changes GitHub documentation to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Participants who wish to perform an analysis of the data as part of this effort 
 Contributions to the analysis repository operate on a pull request model.
 We expect participants to actively review pull requests, with a particular focus on pull requests that include analyses within their areas of expertise.
 
-_If you are new to git and GitHub, check out [this Hello World guide](https://guides.github.com/activities/hello-world/) and [the GitHub documentation for reviewing changes in pull requests](https://help.github.com/en/articles/reviewing-changes-in-pull-requests)._
+_If you are new to git and GitHub, check out [this Hello World guide](https://guides.github.com/activities/hello-world/), [the GitHub documentation for cloning a repository](https://help.github.com/en/articles/cloning-a-repository), [the GitHub documentation for changes from a remote repository](https://help.github.com/en/articles/getting-changes-from-a-remote-repository) and [the GitHub documentation for reviewing changes in pull requests](https://help.github.com/en/articles/reviewing-changes-in-pull-requests)._
 
 ### Filing a pull request from your own branch
 


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

#### Purpose/implementation

We did not have information around local copies of the repository in our contributing guidelines. The Hello World tutorial does not cover cloning. This adds two links to contributing guidelines: GitHub documentation for cloning and GitHub documentation for getting changes from a remote repository.
