### PR TITLE
Remove old symlinks when downloading data

### DIFF
--- a/download-data.sh
+++ b/download-data.sh
@@ -6,6 +6,9 @@ set -o pipefail
 URL=${URL:-https://s3.amazonaws.com/kf-openaccess-us-east-1-prd-pbta/data}
 RELEASE=${RELEASE:-release-v5-20190924}
 
+# Remove symlinks in data
+find data -type l -delete
+
 # The md5sum file provides our single point of truth for which files are in a release.
 curl --create-dirs $URL/$RELEASE/md5sum.txt -o data/$RELEASE/md5sum.txt -z data/$RELEASE/md5sum.txt
 


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

#### Purpose/implementation

With data release v5 #127, we had the expression data files get split up and the merged file was removed. That means running `bash download-data.sh` left old symlinks to files that are no longer in the current release in the `data/` directory. This could be a source of error. In addition, new symlinks are not created when the checksum step fails. Without this step, someone may not realize that they are not linking to the most recent data files.

#### Issue

N/A

#### Directions for reviewers

Check out my branch and see that this works please. I think this should work on Mac OS X and Linux without any additional software.
