### PR TITLE
FIX: data directory for CI txome dimension reduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,9 @@ The contents of `analyses/gene-expression-clustering/run-gene-expression-cluster
 # This script runs the gene-expression-clustering analysis
 # Author's Name 2019
 
+set -e
+set -o pipefail
+
 Rscript --vanilla analyses/gene-expression-clustering/01-filter-samples.R
 Rscript --vanilla analyses/gene-expression-clustering/02-cluster-heatmap.R
 ```

--- a/analyses/transcriptomic-dimension-reduction/ci-dimension-reduction-plots.sh
+++ b/analyses/transcriptomic-dimension-reduction/ci-dimension-reduction-plots.sh
@@ -3,6 +3,9 @@
 # Bethell and Taroni for CCDL 2019
 # Run the dimension reduction plotting pipeline specifically in CI
 
+set -e
+set -o pipefail
+
 # This script should always run as if it were being called from
 # the directory it lives in.
 script_directory="$(perl -e 'use File::Basename;
@@ -12,16 +15,16 @@ cd "$script_directory" || exit
 
 # Run stranded RSEM file with low perplexity
 Rscript --vanilla scripts/run-dimension-reduction.R \
-  --expression data/pbta-gene-expression-rsem-fpkm.stranded.rds \
-  --metadata data/pbta-histologies.tsv \
+  --expression ../../data/pbta-gene-expression-rsem-fpkm.stranded.rds \
+  --metadata ../../data/pbta-histologies.tsv \
   --filename_lead rsem_stranded \
   --output_directory results \
   --perplexity 5 
 
 # Run poly-A kallisto file, skipping t-SNE
 Rscript --vanilla scripts/run-dimension-reduction.R \
-  --expression data/pbta-gene-expression-kallisto.polya.rds \
-  --metadata data/pbta-histologies.tsv \
+  --expression ../../data/pbta-gene-expression-kallisto.polya.rds \
+  --metadata ../../data/pbta-histologies.tsv \
   --filename_lead kallisto_polyA \
   --output_directory results \
   --skip_tsne

--- a/analyses/transcriptomic-dimension-reduction/ci-dimension-reduction-plots.sh
+++ b/analyses/transcriptomic-dimension-reduction/ci-dimension-reduction-plots.sh
@@ -27,7 +27,8 @@ Rscript --vanilla scripts/run-dimension-reduction.R \
   --metadata ../../data/pbta-histologies.tsv \
   --filename_lead kallisto_polyA \
   --output_directory results \
-  --skip_tsne
+  --skip_tsne \
+  --neighbors 2
 
 # generate plot lists for both cases above
 Rscript --vanilla scripts/get-plot-list.R  \

--- a/analyses/transcriptomic-dimension-reduction/dimension-reduction-plots.sh
+++ b/analyses/transcriptomic-dimension-reduction/dimension-reduction-plots.sh
@@ -4,6 +4,9 @@
 # Run the dimension reduction plotting pipeline. Samples will be colored by
 # user-specified variable. It will be broad_histology by default.
 
+set -e
+set -o pipefail
+
 COLORVAR=${COLOR:-broad_histology}
 
 # This script should always run as if it were being called from


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

#### Purpose/implementation

The CI script for `transcriptomic-dimension-reduction` used the incorrect data directory, but still passed.

#### Issue

This is something I noticed as part of #139 

#### Docker and continuous integration

_Check all those that apply or remove this section if it is not applicable._

- [x] The dependencies required to run the code in this pull request have been added to the project Dockerfile.
- [x] This analysis has been added to continuous integration.
