### PR TITLE
Move SNV caller analysis to last step in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,10 +43,6 @@ jobs:
           command: ./scripts/run_in_ci.sh ./analyses/transcriptomic-dimension-reduction/ci-dimension-reduction-plots.sh 
 
       - run:
-          name: SNV Caller Analysis 
-          command: OPENPBTA_VAF_CUTOFF=0.5 ./scripts/run_in_ci.sh bash analyses/snv-callers/run_caller_evals.sh    
-
-      - run:
           name: Sex prediction from RNA-seq
           command: ./scripts/run_in_ci.sh Rscript -e "rmarkdown::render('analyses/sex-prediction-from-RNASeq/sex-prediction-from-RNASeq.Rmd', clean = TRUE)"
           
@@ -66,8 +62,15 @@ jobs:
           name: Independent samples
           command: ./scripts/run_in_ci.sh Rscript -e "rmarkdown::render('analyses/independent-samples/00-repeated-samples.Rmd', clean = TRUE)"
  
+         ################################
          #### Add your analysis here ####
-                 
+         ################################
+
+      - run:
+          name: SNV Caller Analysis 
+          command: OPENPBTA_VAF_CUTOFF=0.5 ./scripts/run_in_ci.sh bash analyses/snv-callers/run_caller_evals.sh    
+
+                
   deploy:
     machine: 
       docker_layer_caching: true


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

#### Purpose/implementation

The SNV caller step's run time has been shortened with #168 and #163, but it still is ~3x longer than any other step. Here I'm moving it to the last step (per a suggestion from @jashapiro yesterday) and (hopefully) making it more obvious where folks should add their analyses.

As a result, people submitting PRs to see if they need to make changes more quickly than if they added their analyses after this SNV step.

Alternative idea: add the "add your analysis here" after 

```
      - run:
          name: List Data Directory Contents
          command: ./scripts/run_in_ci.sh ls data/testing
```

#### Issue

N/A - contributor friendliness

#### Docker and continuous integration

_Check all those that apply or remove this section if it is not applicable._

- [x] The dependencies required to run the code in this pull request have been added to the project Dockerfile.
- [x] This analysis has been added to continuous integration.
