### PR TITLE
Modifications required for generating v7 files for continuous integration

### DIFF
--- a/analyses/create-subset-files/01-get_biospecimen_identifiers.R
+++ b/analyses/create-subset-files/01-get_biospecimen_identifiers.R
@@ -54,9 +54,13 @@ get_biospecimen_ids <- function(filename, id_mapping_df) {
                                   data.table = FALSE)
     biospecimen_ids <- unique(snv_file$Tumor_Sample_Barcode)
   } else if (grepl("pbta-cnv", filename)) {
-    # in a column 'ID'
+    # the two CNV files now have different structures
     cnv_file <- read_tsv(filename)
-    biospecimen_ids <- unique(cnv_file$ID)
+    if (grepl("controlfreec", filename)) {
+      biospecimen_ids <- unique(cnv_file$tumor)
+    } else {
+      biospecimen_ids <- unique(cnv_file$ID)
+    }
   } else if (grepl("pbta-fusion", filename)) {
     # in a column 'tumor_id'
     fusion_file <- read_tsv(filename)

--- a/analyses/create-subset-files/01-get_biospecimen_identifiers.R
+++ b/analyses/create-subset-files/01-get_biospecimen_identifiers.R
@@ -167,6 +167,9 @@ participant_id_list <- purrr::map(files_to_subset,
                                   ~ get_biospecimen_ids(.x, id_mapping_df)) %>%
   stats::setNames(files_to_subset)
 
+# explicitly perform garbage collection here
+gc(verbose = FALSE)
+
 # split up information for poly-A and stranded expression data vs. all else
 polya_participant_list <- purrr::keep(
   participant_id_list,

--- a/analyses/create-subset-files/02-subset_files.R
+++ b/analyses/create-subset-files/02-subset_files.R
@@ -86,8 +86,9 @@ subset_files <- function(filename, biospecimen_ids, output_directory) {
     
     # in a column 'ID'
     cnv_file <- readr::read_tsv(filename)
+    biospecimen_column <- intersect(colnames(cnv_file), c("ID", "tumor"))
     cnv_file %>%
-      dplyr::filter(ID %in% biospecimen_ids) %>%
+      dplyr::filter(!!rlang::sym(biospecimen_column) %in% biospecimen_ids) %>%
       readr::write_tsv(output_file)
     
   } else if (grepl("pbta-fusion", filename)) {

--- a/analyses/create-subset-files/create_subset_files.sh
+++ b/analyses/create-subset-files/create_subset_files.sh
@@ -7,7 +7,7 @@ set -o pipefail
 
 # Set defaults for release and biospecimen file name
 BIOSPECIMEN_FILE=${BIOSPECIMEN_FILE:-biospecimen_ids_for_subset.RDS}
-RELEASE=${RELEASE:-release-v6-20191030}
+RELEASE=${RELEASE:-release-v7-20191031}
 NUM_MATCHED=${NUM_MATCHED:-15}
 
 # This script should always run as if it were being called from
@@ -39,6 +39,9 @@ Rscript --vanilla 02-subset_files.R \
 
 # histologies file
 cp $FULL_DIRECTORY/pbta-histologies.tsv $SUBSET_DIRECTORY
+
+# independent specimen files
+cp $FULL_DIRECTORY/independent-specimens*.tsv $SUBSET_DIRECTORY
 
 # all bed files
 cp $FULL_DIRECTORY/*.bed $SUBSET_DIRECTORY


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

#### Purpose/implementation

Release v7 #200 was reverted in #202, but we'll still need to generate new files for CI soon! Here I'm making the appropriate changes to the `create-subset-files` module in preparation.

#### Issue

#197 

#### Directions for reviewers

@cansavvy can you run this one once the v7 changes are in master? Same steps as #180. If the SEG files both end up with `ID` columns (see https://github.com/AlexsLemonade/OpenPBTA-analysis/issues/194#issuecomment-548608326), I think you should be able to revert https://github.com/AlexsLemonade/OpenPBTA-analysis/commit/61476d080fd47da149e7e8e9740044d729fc89f7. Thank you!
