### PR TITLE
Conda coreutils

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Users performing analyses, should always refer to the symlinks in the `data/` di
 We have created a shell script that will download the latest release from AWS S3.
 OS X users must use [homebrew](https://brew.sh/) to install `md5sha1sum` via the command `brew install md5sha1sum` before running the download script the first time.
 Once this has been done, run `bash download-data.sh` to acquire the latest release.
-Alternatively, `md5sha1sum` can be installed through [conda/miniconda](https://docs.conda.io/projects/conda/en/latest/) via the command `conda install -c conda-forge coreutils`.
+Alternatively, the required utilities can be installed through [conda/miniconda](https://docs.conda.io/projects/conda/en/latest/) via the command `conda install -c conda-forge coreutils`.
 This will create symlinks in `data/` to the latest files.
 It's safe to re-run `bash download-data.sh` to check that you have the most recent release of the data.
 We will update the default release number whenever we produce a new release.

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Users performing analyses, should always refer to the symlinks in the `data/` di
 We have created a shell script that will download the latest release from AWS S3.
 OS X users must use [homebrew](https://brew.sh/) to install `md5sha1sum` via the command `brew install md5sha1sum` before running the download script the first time.
 Once this has been done, run `bash download-data.sh` to acquire the latest release.
+Alternatively, `md5sha1sum` can be installed through [conda/miniconda](https://docs.conda.io/projects/conda/en/latest/) via the command `conda install -c conda-forge coreutils`.
 This will create symlinks in `data/` to the latest files.
 It's safe to re-run `bash download-data.sh` to check that you have the most recent release of the data.
 We will update the default release number whenever we produce a new release.

--- a/README.md
+++ b/README.md
@@ -68,9 +68,10 @@ Users performing analyses, should always refer to the symlinks in the `data/` di
 ### Data Access via Download Script
 
 We have created a shell script that will download the latest release from AWS S3.
-OS X users must use [homebrew](https://brew.sh/) to install `md5sha1sum` via the command `brew install md5sha1sum` before running the download script the first time.
+macOS users must install `md5sum` before running the download script the first time. 
+This installed with [homebrew](https://brew.sh/) via the command `brew install md5sha1sum` or [conda/miniconda](https://docs.conda.io/projects/conda/en/latest/) via the command `conda install -c conda-forge coreutils`.
+
 Once this has been done, run `bash download-data.sh` to acquire the latest release.
-Alternatively, the required utilities can be installed through [conda/miniconda](https://docs.conda.io/projects/conda/en/latest/) via the command `conda install -c conda-forge coreutils`.
 This will create symlinks in `data/` to the latest files.
 It's safe to re-run `bash download-data.sh` to check that you have the most recent release of the data.
 We will update the default release number whenever we produce a new release.


### PR DESCRIPTION
#### Purpose/implementation

An alternative install method for `md5sum` on macs that doesn't require homebrew.


