### PR TITLE
Revert "V8 Release"

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -1,54 +1,5 @@
 # release notes
 ## current release
-### release-v8-20191104
-- release date: 2019-11-04
-- status: available
-- changes:
-  - Updated clinical file
-    - fixed error in `primary_site`: [#214](https://github.com/AlexsLemonade/OpenPBTA-analysis/issues/214)
-  - Updated ControlFreeC TSV file
-    - added `tumor_ploidy` and updated `genotype` to `segment_genotype`: [PR comment](https://github.com/AlexsLemonade/OpenPBTA-analysis/pull/216#discussion_r341868007)
-  - Updated RNA-Seq FPKM merge files
-    - fixed ID merge error: [#221](https://github.com/AlexsLemonade/OpenPBTA-analysis/issues/221) 
-- folder structure:
-```
-data
-└── release-v8-20191104
-    ├── CHANGELOG.md
-    ├── StrexomeLite_Targets_CrossMap_hg38_filtered_chr_prefixed.bed
-    ├── StrexomeLite_hg38_liftover_100bp_padded.bed
-    ├── WGS.hg38.lancet.300bp_padded.bed
-    ├── WGS.hg38.lancet.unpadded.bed
-    ├── WGS.hg38.mutect2.unpadded.bed
-    ├── WGS.hg38.strelka2.unpadded.bed
-    ├── WGS.hg38.vardict.100bp_padded.bed
-    ├── WXS.hg38.100bp_padded.bed
-    ├── md5sum.txt
-    ├── pbta-cnv-cnvkit.seg.gz
-    ├── pbta-cnv-controlfreec.tsv.gz
-    ├── pbta-fusion-arriba.tsv.gz
-    ├── pbta-fusion-starfusion.tsv.gz
-    ├── pbta-gene-counts-rsem-expected_count.polya.rds
-    ├── pbta-gene-counts-rsem-expected_count.stranded.rds
-    ├── pbta-gene-expression-kallisto.polya.rds
-    ├── pbta-gene-expression-kallisto.stranded.rds
-    ├── pbta-gene-expression-rsem-fpkm.polya.rds
-    ├── pbta-gene-expression-rsem-fpkm.stranded.rds
-    ├── pbta-histologies.tsv
-    ├── pbta-isoform-counts-rsem-expected_count.polya.rds
-    ├── pbta-isoform-counts-rsem-expected_count.stranded.rds
-    ├── pbta-snv-lancet.vep.maf.gz
-    ├── pbta-snv-mutect2.vep.maf.gz
-    ├── pbta-snv-strelka2.vep.maf.gz
-    ├── pbta-snv-vardict.vep.maf.gz
-    ├── pbta-sv-manta.tsv.gz
-    ├── independent-specimens.wgs.primary-plus.tsv
-    ├── independent-specimens.wgs.primary.tsv
-    ├── independent-specimens.wgswxs.primary-plus.tsv
-    └── independent-specimens.wgswxs.primary.tsv
-```
-
-## archived release
 ### release-v7-20191031
 - release date: 2019-10-31 :jack_o_lantern:
 - status: available
@@ -100,6 +51,7 @@ data
     └── independent-specimens.wgswxs.primary.tsv
 ```
 
+## archived release
 ### release-v6-20191030
 - release date: 2019-10-30
 - status: available

--- a/download-data.sh
+++ b/download-data.sh
@@ -4,7 +4,7 @@ set -o pipefail
 
 # Use the OpenPBTA bucket as the default.
 URL=${URL:-https://s3.amazonaws.com/kf-openaccess-us-east-1-prd-pbta/data}
-RELEASE=${RELEASE:-release-v8-20191104}
+RELEASE=${RELEASE:-release-v7-20191031}
 
 # Remove symlinks in data
 find data -type l -delete


### PR DESCRIPTION
Reverts AlexsLemonade/OpenPBTA-analysis#223

The v8 data download is currently not working properly. I get the following error running `bash download-data.sh`:

```
pbta-histologies.tsv: FAILED
WGS.hg38.lancet.300bp_padded.bed: OK
WGS.hg38.lancet.unpadded.bed: OK
WGS.hg38.mutect2.unpadded.bed: OK
WGS.hg38.strelka2.unpadded.bed: OK
WGS.hg38.vardict.100bp_padded.bed: OK
WXS.hg38.100bp_padded.bed: OK
StrexomeLite_hg38_liftover_100bp_padded.bed: OK
StrexomeLite_Targets_CrossMap_hg38_filtered_chr_prefixed.bed: OK
pbta-snv-mutect2.vep.maf.gz: OK
pbta-snv-strelka2.vep.maf.gz: OK
pbta-snv-lancet.vep.maf.gz: OK
pbta-snv-vardict.vep.maf.gz: OK
pbta-cnv-cnvkit.seg.gz: OK
pbta-cnv-controlfreec.tsv.gz: FAILED
pbta-sv-manta.tsv.gz: OK
pbta-gene-expression-kallisto.polya.rds: OK
pbta-gene-expression-kallisto.stranded.rds: OK
pbta-gene-counts-rsem-expected_count.polya.rds: FAILED
pbta-gene-counts-rsem-expected_count.stranded.rds: FAILED
pbta-gene-expression-rsem-fpkm.polya.rds: FAILED
pbta-gene-expression-rsem-fpkm.stranded.rds: FAILED
pbta-isoform-counts-rsem-expected_count.polya.rds: OK
pbta-isoform-counts-rsem-expected_count.stranded.rds: OK
pbta-fusion-arriba.tsv.gz: OK
pbta-fusion-starfusion.tsv.gz: OK
independent-specimens.wgs.primary-plus.tsv: OK
independent-specimens.wgs.primary.tsv: OK
independent-specimens.wgswxs.primary-plus.tsv: OK
md5sum: WARNING: 6 of 29 computed checksums did NOT match
```

Here are the ones with the reported mismatch that I get via the download script:

```sh
e169263abfed11959dc8cd9fea6593c9  data/release-v8-20191104/pbta-cnv-controlfreec.tsv.gz
b7427379c87ee9c8f60f3dca913fc974  data/release-v8-20191104/pbta-gene-counts-rsem-expected_count.polya.rds
d53ba7039c7fb70fd3ba7f72cad954a7  data/release-v8-20191104/pbta-gene-counts-rsem-expected_count.stranded.rds
af3d3c813bbc92d712c98bbb472fc229  data/release-v8-20191104/pbta-gene-expression-rsem-fpkm.polya.rds
286fc3888f418ad831bfe9307fdb580d  data/release-v8-20191104/pbta-gene-expression-rsem-fpkm.stranded.rds
e8d45ebd57b01d3ae655cdf0955c833f  data/release-v8-20191104/pbta-histologies.tsv
```

Here are the checksums for those 6 files in the `data/release-v7-20191031/md5sum.txt`:

```
e169263abfed11959dc8cd9fea6593c9  pbta-cnv-controlfreec.tsv.gz
b7427379c87ee9c8f60f3dca913fc974  pbta-gene-counts-rsem-expected_count.polya.rds
d53ba7039c7fb70fd3ba7f72cad954a7  pbta-gene-counts-rsem-expected_count.stranded.rds
af3d3c813bbc92d712c98bbb472fc229  pbta-gene-expression-rsem-fpkm.polya.rds
286fc3888f418ad831bfe9307fdb580d  pbta-gene-expression-rsem-fpkm.stranded.rds
e8d45ebd57b01d3ae655cdf0955c833f  pbta-histologies.tsv
```

and the checksums for those 6 files in `data/release-v8-20191104/md5sum.txt`:

```
f273ad7e5bc470cf1529357606ff1a71  pbta-cnv-controlfreec.tsv.gz
a83df80afb7b0262ec13e4c644a30178  pbta-gene-counts-rsem-expected_count.polya.rds
b73728ed87ae995cc2296b762b6a8c53  pbta-gene-counts-rsem-expected_count.stranded.rds
40043027e90b3f009d6146450d150d68  pbta-gene-expression-rsem-fpkm.polya.rds
425bba0dd410a1752b965a2507ba0134  pbta-gene-expression-rsem-fpkm.stranded.rds
26cf6eb434eeb4c4520723a07e3e93a5  pbta-histologies.tsv
```

So most likely answer is the v8 files didn't make it to S3 correctly quite yet.