### PR TITLE
Drop metadata columns from SNV consensus file

### DIFF
--- a/analyses/snv-callers/run_caller_analysis.sh
+++ b/analyses/snv-callers/run_caller_analysis.sh
@@ -84,6 +84,7 @@ Rscript analyses/snv-callers/scripts/04-create_consensus_mut_files.R \
  --combo lancet-mutect2-strelka2 \
  --output analyses/snv-callers/results/consensus \
  --vaf strelka2 \
+ --metadata data/pbta-histologies.tsv \
  --bed_wgs data/WGS.hg38.strelka2.unpadded.bed \
  --bed_wxs data/WXS.hg38.100bp_padded.bed \
  --overwrite

--- a/analyses/snv-callers/scripts/04-create_consensus_mut_files.R
+++ b/analyses/snv-callers/scripts/04-create_consensus_mut_files.R
@@ -219,6 +219,12 @@ if (file.exists(consensus_mut_file) && !opt$overwrite) {
        the combination you specified with --combo is spelled exactly right and
        the callers are in alphabetical order. ")
   }
+  # Isolate the mutations to only these mutations, use the Strelka2 stats.
+  consen_mutation <- vaf_df %>%
+    dplyr::filter(
+      caller == opt$vaf,
+      mutation_id %in% consen_mutations
+    )
 
 ############################### Re-calculate TMB ###############################
 # If the file exists or the overwrite option is not being used, do not create
@@ -258,12 +264,8 @@ meta_cols <- colnames(readr::read_tsv(opt$metadata, n_max = 1))
 
 ########################### Write consensus file ###############################
 # Isolate the mutations to only these mutations, use the Strelka2 stats.
-consen_mutation <- vaf_df %>%
+consen_mutation <- consen_mutation %>%
   dplyr::select(-!(colnames(vaf_df) %in% meta_cols)) %>%
-  dplyr::filter(
-    caller == opt$vaf,
-    mutation_id %in% consen_mutations
-  ) %>%
   readr::write_tsv(consensus_mut_file)
 
 # Zip this file up.

--- a/analyses/snv-callers/scripts/04-create_consensus_mut_files.R
+++ b/analyses/snv-callers/scripts/04-create_consensus_mut_files.R
@@ -252,7 +252,6 @@ if (file.exists(consensus_tmb_file) && !opt$overwrite) {
   # Give message
   message("Consensus mutations and TMB re-calculations saved in: \n", opt$output)
 }
-vaf_df <- readr::read_tsv(file.path("data", "consensus_mutation.maf.tsv"))
 
 ###################### Determine what the metadata columns are #################
 meta_cols <- colnames(readr::read_tsv(opt$metadata, n_max = 1))

--- a/analyses/snv-callers/scripts/04-create_consensus_mut_files.R
+++ b/analyses/snv-callers/scripts/04-create_consensus_mut_files.R
@@ -70,6 +70,11 @@ option_list <- list(
     metavar = "character"
   ),
   make_option(
+    opt_str = c("--metadata"), type = "character",
+    default = FALSE, help = "What metadata file was used? columns should be removed",
+    metavar = "character"
+  ),
+  make_option(
     opt_str = c("--combo"), type = "character",
     default = FALSE, help = "What combination of callers need to detect a
     mutation for it to be considered real and placed in the consensus file?
@@ -104,12 +109,17 @@ opt <- parse_args(OptionParser(option_list = option_list))
 # Normalize these file paths
 opt$merged_dir <- file.path(root_dir, opt$merged_dir)
 opt$output <- file.path(root_dir, opt$output)
+opt$metadata <- file.path(root_dir, opt$metadata)
 opt$bed_wgs <- file.path(root_dir, opt$bed_wgs)
 opt$bed_wxs <- file.path(root_dir, opt$bed_wxs)
 
 # Check the output directory exists
 if (!dir.exists(opt$merged_dir)) {
   stop(paste("Error:", opt$merged_dir, "does not exist"))
+}
+# Check for metadata
+if (!file.exists(opt$metadata)) {
+  stop(paste("Error:", opt$metadata, "does not exist"))
 }
 # Check for BED files
 if (!file.exists(opt$bed_wgs)) {
@@ -210,17 +220,6 @@ if (file.exists(consensus_mut_file) && !opt$overwrite) {
        the callers are in alphabetical order. ")
   }
 
-  # Isolate the mutations to only these mutations, use the Strelka2 stats.
-  consen_mutation <- vaf_df %>%
-    dplyr::filter(
-      caller == opt$vaf,
-      mutation_id %in% consen_mutations
-    ) %>%
-    readr::write_tsv(consensus_mut_file)
-
-  # Zip this file up.
-  zip(consensus_mut_zip_file, consensus_mut_file)
-}
 ############################### Re-calculate TMB ###############################
 # If the file exists or the overwrite option is not being used, do not create
 # the consensus TMB file
@@ -252,4 +251,22 @@ if (file.exists(consensus_tmb_file) && !opt$overwrite) {
 
   # Give message
   message("Consensus mutations and TMB re-calculations saved in: \n", opt$output)
+}
+vaf_df <- readr::read_tsv(file.path("data", "consensus_mutation.maf.tsv"))
+
+###################### Determine what the metadata columns are #################
+meta_cols <- colnames(readr::read_tsv(opt$metadata, n_max = 1))
+
+########################### Write consensus file ###############################
+# Isolate the mutations to only these mutations, use the Strelka2 stats.
+consen_mutation <- vaf_df %>%
+  dplyr::select(-!(colnames(vaf_df) %in% meta_cols)) %>%
+  dplyr::filter(
+    caller == opt$vaf,
+    mutation_id %in% consen_mutations
+  ) %>%
+  readr::write_tsv(consensus_mut_file)
+
+# Zip this file up.
+zip(consensus_mut_zip_file, consensus_mut_file)
 }


### PR DESCRIPTION

### Purpose/implementation Section

#### What scientific question is your analysis addressing?

See #262 , the metadata columns appended to this consensus SNV file need to be dropped. It's not a scientific question but a data wrangling issue. 

#### What was your approach?

I have a short term solution written here, and an intermediate term solution changed in the code for this PR. This whole pipeline is currently being refactored according to #201, hence why I'm calling it an intermediate term solution. 

#### What GitHub issue does your pull request address?

#262 

### Directions for reviewers. Tell potential reviewers what kind of feedback you are soliciting.

Does this address the problem in an acceptable manner? 

#### Temporary Solution: 
So this consensus file can be added to v10, I've implemented a temporary solution by doing the following:

```
vaf_df <- readr::read_tsv(file.path("data", "consensus_mutation.maf.tsv"))
meta_cols <- colnames(readr::read_tsv(file.path("data", "consensus_mutation.maf.tsv")))
consen_mutation <- vaf_df %>%
  dplyr::select(-!(colnames(vaf_df) %in% meta_cols)) %>%
  readr::write_tsv("consensus_mutation.maf.tsv")
```

The output tsv file from this has been added to the already existing TMB file, and is zipped together with as `snv-consensus_11122019.zip`. This is ready to add to S3 and I will add it as soon as this is approved. 

#### Intermediate term solution 

Can be seen in the file changes: 
- Read in metadata file columns
- Drop those columns after TMB has been calculated from that information. 

**Note that everything will be refactored #201 

#### Reproducibility Checklist

No changes to these things were needed for this. 
- [x] The dependencies required to run the code in this pull request have been added to the project Dockerfile.
- [x] This analysis has been added to continuous integration.
