### PR TITLE
Add table of contents to main README with doctoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,41 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [OpenPBTA-analysis](#openpbta-analysis)
+    - [Join the Cancer Data Science Slack](#join-the-cancer-data-science-slack)
+  - [How to Participate](#how-to-participate)
+    - [Planned Analyses](#planned-analyses)
+    - [Proposing a New Analysis](#proposing-a-new-analysis)
+    - [Implementing an Analysis](#implementing-an-analysis)
+      - [Analytical Code and Output](#analytical-code-and-output)
+      - [Software Dependencies](#software-dependencies)
+      - [Pull Request Model](#pull-request-model)
+  - [How to Obtain OpenPBTA Data](#how-to-obtain-openpbta-data)
+    - [Data Access via Download Script](#data-access-via-download-script)
+    - [Data Access via CAVATICA](#data-access-via-cavatica)
+  - [Data Formats](#data-formats)
+    - [Data Caveats](#data-caveats)
+  - [How to Add an Analysis](#how-to-add-an-analysis)
+    - [Folder Structure](#folder-structure)
+    - [Analysis Script Numbering](#analysis-script-numbering)
+    - [Output Expectations](#output-expectations)
+    - [Docker Image](#docker-image)
+      - [Development in the Project Docker Container](#development-in-the-project-docker-container)
+        - [RStudio](#rstudio)
+    - [Local Development](#local-development)
+      - [RStudio](#rstudio-1)
+    - [Continuous Integration (CI)](#continuous-integration-ci)
+      - [Working with the subset files used in CI locally](#working-with-the-subset-files-used-in-ci-locally)
+      - [Adding Analyses to CI](#adding-analyses-to-ci)
+      - [Adding Analyses with Multiple Steps](#adding-analyses-with-multiple-steps)
+        - [1. File and merge a pull request for adding `01-filter-samples.R` to the repository.](#1-file-and-merge-a-pull-request-for-adding-01-filter-samplesr-to-the-repository)
+        - [2. File and merge a pull request for adding `02-cluster-heatmap.R` to the repository.](#2-file-and-merge-a-pull-request-for-adding-02-cluster-heatmapr-to-the-repository)
+        - [3. File and merge a pull request for the shell script that runs the entirety of `gene-expression-clustering`.](#3-file-and-merge-a-pull-request-for-the-shell-script-that-runs-the-entirety-of-gene-expression-clustering)
+      - [Passing variables only in CI](#passing-variables-only-in-ci)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # OpenPBTA-analysis
 
 The Open Pediatric Brain Tumor Atlas (OpenPBTA) Project is an effort to describe the landscape of tumors in the [Children's Brain Tumor Tissue Consortium](https://cbttc.org/) and the PNOC003 DIPG clinical trial from the [Pediatric Pacific Neuro-oncology Consortium](http://www.pnoc.us/).


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

### Purpose/implementation Section

The main README is pretty long and full of important information. I've found myself wishing we had a table of contents several times over the past few weeks to make it easier to find information. Here, I'm adding a table of contents that was generated using [`doctoc`](https://www.npmjs.com/package/doctoc).

#### What GitHub issue does your pull request address?

N/A - this is general contributor friendliness change

### Directions for reviewers. Tell potential reviewers what kind of feedback you are soliciting.

#### Which areas should receive a particularly close look?

Does this seem reasonable or should some headers in the README be changed?