### PR TITLE
Add requirement for module-specific README

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Users performing analyses, should **always** refer to the symlinks in the `data/
 ### Folder Structure
 
 Our folder structure is designed to separate each analysis into its own set of notebooks that are independent of other analyses.
-Within the analyses directory, create a folder for your analysis.
+Within the `analyses` directory, create a folder for your analysis.
 Choose a name that is unique from other analyses and somewhat detailed.
 For example, instead of `gene-expression`, choose `gene-expression-clustering` if you are clustering samples by their gene expression values.
 You should assume that any data files are in the `../../data` directory and that their file names match what the `download-data.sh` script produces.
@@ -141,6 +141,7 @@ Files that are primarily tabular results files should be placed in a `results` s
 Intermediate files that are useful within the processing steps but that do not represent final results should be placed in `../../scratch/`.
 It is safe to assume that files placed in `../../scratch` will be available to all analyses within the same folder.
 It is not safe to assume that files placed in `../../scratch` will be available from analyses in a different folder.
+When an analysis module contains multiple steps or is nearing completion, a `README.md` file should be added to the folder that summarizes the purpose of the module, any known limitations or required updates, and includes examples for how to run the analyses.
 
 An example highlighting a `new-analysis` directory is shown below.
 The directory is placed alongside existing analyses within the `analyses` directory.
@@ -151,6 +152,7 @@ The author has produced their output figures as `.pdf` files.
 We have a preference for vector graphics as PDF files, though other forms of vector graphics are also appropriate.
 The results folder contains a tabular summary as a comma separated values file.
 We expect that the file suffix (`.csv`, `.tsv`) should accurately denote the format of the files added.
+The author has also included a `README.md`.
 
 ```
 OpenPBTA-analysis
@@ -162,6 +164,7 @@ OpenPBTA-analysis
 │       ├── 01-preprocess-data.Rmd
 │       ├── 02-run-analyses.Rmd
 │       ├── 03-make-figures.Rmd
+│       ├── README.md
 │       ├── plots
 │       │   ├── figure1.pdf
 │       │   └── figure2.pdf

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Files that are primarily tabular results files should be placed in a `results` s
 Intermediate files that are useful within the processing steps but that do not represent final results should be placed in `../../scratch/`.
 It is safe to assume that files placed in `../../scratch` will be available to all analyses within the same folder.
 It is not safe to assume that files placed in `../../scratch` will be available from analyses in a different folder.
-When an analysis module contains multiple steps or is nearing completion, a `README.md` file should be added to the folder that summarizes the purpose of the module, any known limitations or required updates, and includes examples for how to run the analyses.
+When an analysis module contains multiple steps or is nearing completion, add a `README.md` file that summarizes the purpose of the module, any known limitations or required updates, and includes examples for how to run the analyses to the folder.
 
 An example highlighting a `new-analysis` directory is shown below.
 The directory is placed alongside existing analyses within the `analyses` directory.
@@ -151,7 +151,7 @@ However, the author could have used Jupyter notebooks, R scripts, or another scr
 The author has produced their output figures as `.pdf` files.
 We have a preference for vector graphics as PDF files, though other forms of vector graphics are also appropriate.
 The results folder contains a tabular summary as a comma separated values file.
-We expect that the file suffix (`.csv`, `.tsv`) should accurately denote the format of the files added.
+ We expect that the file suffix (`.csv`, `.tsv`) accurately denotes the format of the added files.
 The author has also included a `README.md`.
 
 ```


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

### Purpose/implementation Section

The project has matured (read: expanded) to the point where I think we should require that analysis modules in `analyses` contain README.