### PR TITLE
Add "deprecated" to Mutect2, Strelka2 comparison README

### DIFF
--- a/analyses/mutect2-vs-strelka2/README.md
+++ b/analyses/mutect2-vs-strelka2/README.md
@@ -1,6 +1,6 @@
-# Mutect2 vs Strelka2: SNV caller comparison analysis
+# DEPRECATED: Mutect2 vs Strelka2: SNV caller comparison analysis
 
-This original analysis evaluated Mutect2 and Strelka2 mutation calls by comparing their [MAF files](https://docs.gdc.cancer.gov/Data/File_Formats/MAF_Format/) but has since been superseded by the more [comprehensive analysis for all four SNV Callers](https://github.com/AlexsLemonade/OpenPBTA-analysis/tree/master/analyses/snv-callers).
+This deprecated analysis evaluated Mutect2 and Strelka2 mutation calls by comparing their [MAF files](https://docs.gdc.cancer.gov/Data/File_Formats/MAF_Format/) but has since been superseded by the more [comprehensive analysis for all four SNV Callers](https://github.com/AlexsLemonade/OpenPBTA-analysis/tree/master/analyses/snv-callers).
 The original issue for this analysis is [here](https://github.com/AlexsLemonade/OpenPBTA-analysis/issues/30).
 The findings of this analysis led to the addition of two other mutation callers, [VarDict and Lancet](https://github.com/AlexsLemonade/OpenPBTA-analysis/issues/103).
 


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

### Purpose/implementation Section

From @sjspielman in #389:

> This analysis is marked deprecated in the analysis README but not in its own README. Is it really deprecated?

Here I'm indicating that this module is deprecated in the module-specific README.




