### PR TITLE
Use predicted levels to fix intermittently failing test

### DIFF
--- a/analyses/sex-prediction-from-RNASeq/03-evaluate_model.R
+++ b/analyses/sex-prediction-from-RNASeq/03-evaluate_model.R
@@ -178,7 +178,7 @@ saveRDS(cm, cm_file)
 # The underlying cause should be investigated more thoroughly, as we would
 # like the module code to run reproducibly, e.g., get the same labels given
 # the same seed.
-if (length(levels(cm_set$obs)) > 1) {
+if (length(levels(cm_set$pred)) > 1) {
   two_class_summary <- twoClassSummary(cm_set, lev = levels(cm_set$obs))
   cat("\n\n")
   two_class_summary


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

### Purpose/implementation Section

https://github.com/AlexsLemonade/OpenPBTA-analysis/pull/391 did not fix the problem I was attempting to fix because the logic used _observed_ levels and not _predicted_ levels. 