### PR TITLE
Remove redundant question in update-an-analysis issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/update-an-analysis.md
+++ b/.github/ISSUE_TEMPLATE/update-an-analysis.md
@@ -13,10 +13,6 @@ assignees: ''
 
 
 
-#### Why should the module be updated?
-
-
-
 #### What changes need to be made? Please provide enough detail for another participant to make the update.
 
 


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

### Purpose/implementation Section

In #256, we made the HTML comments their own headers. As a result, there's some redundancy in the `update an analysis` issue template that's tripped me up several times recently as I've filled out these tickets.