### PR TITLE
Remove d3r dependency (temporarily?)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,6 @@ RUN apt-get update -qq && apt-get -y --no-install-recommends install \
     --deps TRUE \
     R.utils \
     treemap \
-    d3r \
     hexbin \
     VennDiagram \
     Rtsne \
@@ -45,7 +44,9 @@ RUN apt-get update -qq && apt-get -y --no-install-recommends install \
     pheatmap \
     RColorBrewer \
     viridis \
-    data.table
+    data.table # \
+   # d3r 
+
 
 # maftools for proof of concept in create-subset-files
 RUN R -e "BiocManager::install(c('maftools'), update = FALSE)"

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,7 @@ RUN apt-get update -qq && apt-get -y --no-install-recommends install \
 
 # Install java and rJava for some of the snv plotting comparison packages
 RUN apt-get install -y \
-    default-jdk \
+    default-jdk 
 RUN install2.r --error \
     --deps TRUE \
     rJava

--- a/Dockerfile
+++ b/Dockerfile
@@ -151,7 +151,7 @@ RUN apt-get update -qq && apt-get -y --no-install-recommends install \
 RUN Rscript -e "library(bedr)"
 
 # Install for mutation signature analysis
-RUN R -e "BiocManager::install(c('BSgenome.Hsapiens.UCSC.hg19', 'BSgenome.Hsapiens.UCSC.hg38'))"
+RUN R -e "BiocManager::install(c('BSgenome.Hsapiens.UCSC.hg19', 'BSgenome.Hsapiens.UCSC.hg38'), update=FALSE)"
 
 # Also install for mutation signature analysis
 # qdapRegex is for the fusion analysis
@@ -231,7 +231,7 @@ RUN R -e "remotes::install_github('icbi-lab/immunedeconv', ref = '493bcaa9e1f735
 RUN R -e "install.packages('corrplot', dependencies = TRUE)"
 
 # Install for mutation signature analysis
-RUN R -e "BiocManager::install('ggbio')"
+RUN R -e "BiocManager::install('ggbio', update=FALSE)"
 
 # CRAN package msigdbr needed for gene-set-enrichment-analysis
 RUN apt-get update -qq && apt-get -y --no-install-recommends install \

--- a/analyses/sample-distribution-analysis/02-multilayer-plots.R
+++ b/analyses/sample-distribution-analysis/02-multilayer-plots.R
@@ -12,6 +12,10 @@
 #
 # Rscript analyses/sample-distribution-analysis/02-multilayer-plots.R
 
+print("PRINTING SESSION INFO 0")
+print(sessionInfo())
+
+
 # Load in libraries
 library(ggplot2)
 library(colorspace)
@@ -75,6 +79,8 @@ color_palette <-
     "palettes",
     "histology_color_palette.tsv"
   ))
+  
+
 
 # Join the color palette for the colors for each short histology value --
 # palette is generated in `figures/scripts/color_palettes.R`
@@ -145,6 +151,8 @@ mapview::mapshot(interactive_tm, url = file.path(plots_dir,
                                                  "histology-treemap.html"))
 # mapview::mapshot(p, url = file.path(plots_dir, "histology-pie.html"))
 
+print("PRINTING SESSION INFO 2")
+print(sessionInfo())
 
 ##########################################################################################
 # NOTE: Below is commented out due to d3r leading to CI build fails via tidyselect version conflicts
@@ -152,9 +160,12 @@ mapview::mapshot(interactive_tm, url = file.path(plots_dir,
 # Convert the tm data.frame into a d3.js hierarchy object which is needed
 # for the sund2b plot
 # NOTE: Commented out due to d3r leading to CI build fails via tidyselect version conflicts
-#tmnest <-
-#  d3r::d3_nest(tm[, c("level1", "level2", "level3", "vSize")],
-#               value_cols = c("vSize"))
+tmnest <-
+  d3r::d3_nest(tm[, c("level1", "level2", "level3", "vSize")],
+               value_cols = c("vSize"))
+
+print("PRINTING SESSION INFO 3")
+print(sessionInfo())
 
 
 #

--- a/analyses/sample-distribution-analysis/02-multilayer-plots.R
+++ b/analyses/sample-distribution-analysis/02-multilayer-plots.R
@@ -143,7 +143,7 @@ interactive_tm <-
 # Create HTML outputs for the interactive plots
 mapview::mapshot(interactive_tm, url = file.path(plots_dir,
                                                  "histology-treemap.html"))
-mapview::mapshot(p, url = file.path(plots_dir, "histology-pie.html"))
+# mapview::mapshot(p, url = file.path(plots_dir, "histology-pie.html"))
 
 
 ##########################################################################################

--- a/analyses/sample-distribution-analysis/02-multilayer-plots.R
+++ b/analyses/sample-distribution-analysis/02-multilayer-plots.R
@@ -132,11 +132,6 @@ tm <-
     draw = TRUE
   )$tm
 
-# Convert the tm data.frame into a d3.js hierarchy object which is needed
-# for the sund2b plot
-tmnest <-
-  d3r::d3_nest(tm[, c("level1", "level2", "level3", "vSize")],
-               value_cols = c("vSize"))
 
 # Create an interactive treemap
 interactive_tm <-
@@ -145,20 +140,34 @@ interactive_tm <-
                   width = 1200,
                   height = 700)
 
-# Create a sunburst plot
-sun_plot <-
-  sunburstR::sunburst(
-    data = tmnest,
-    valueField = "vSize",
-    count = TRUE,
-    sumNodes = FALSE,
-    colors = color
-  )
-
-# Create an interactive sund2b plot
-p <- sunburstR::sund2b(tmnest, colors = color, valueField = "vSize")
-
 # Create HTML outputs for the interactive plots
 mapview::mapshot(interactive_tm, url = file.path(plots_dir,
                                                  "histology-treemap.html"))
 mapview::mapshot(p, url = file.path(plots_dir, "histology-pie.html"))
+
+
+##########################################################################################
+# NOTE: Below is commented out due to d3r leading to CI build fails via tidyselect version conflicts
+
+# Convert the tm data.frame into a d3.js hierarchy object which is needed
+# for the sund2b plot
+# NOTE: Commented out due to d3r leading to CI build fails via tidyselect version conflicts
+#tmnest <-
+#  d3r::d3_nest(tm[, c("level1", "level2", "level3", "vSize")],
+#               value_cols = c("vSize"))
+
+
+#
+## Create a sunburst plot
+#sun_plot <-
+#  sunburstR::sunburst(
+#    data = tmnest,
+#    valueField = "vSize",
+#    count = TRUE,
+#    sumNodes = FALSE,
+#    colors = color
+#  )
+
+# Create an interactive sund2b plot
+#p <- sunburstR::sund2b(tmnest, colors = color, valueField = "vSize")
+#########################################################################################

--- a/analyses/survival-analysis/util/survival_models.R
+++ b/analyses/survival-analysis/util/survival_models.R
@@ -137,7 +137,7 @@ survival_analysis <- function(metadata,
     metadata_sample_col <- enquo(metadata_sample_col)
     
     # Set up the sample by thing
-    sample_by <- set_names(quo_name(ind_data_sample_col), quo_name(metadata_sample_col))
+    sample_by <- rlang::set_names(quo_name(ind_data_sample_col), quo_name(metadata_sample_col))
 
     # Join this ind_data to the metadata
     metadata <- dplyr::inner_join(metadata, ind_data,


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

### Purpose/implementation Section

The `d3r` package (obtained from CRAN) has recently, for pending reasons, caused CI build fails related to deprecated use of `tidyselect::one_of`. Current strategy is to remove this dependency and comment out code that uses it, specifically the sunburst plots made in `analyses/sample-distribution-analysis/02-multilayer-plots.R`.


#### What GitHub issue does your pull request address?



#### Reproducibility Checklist

<!-- Check all those that apply or remove this section if it is not applicable.-->

- [X ] The dependencies required to run the code in this pull request have been added to the project Dockerfile.
- [X ] This analysis has been added to continuous integration.
