### PR TITLE
Find v18 breaking changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,9 +156,9 @@ jobs:
           name: Survival analysis
           command: ./scripts/run_in_ci.sh Rscript -e "rmarkdown::render('analyses/survival-analysis/survival-analysis_template.Rmd', params = list(plot_ci = FALSE), clean = TRUE)"
 
-      - run:
-          name: Comparative RNASeq - generate correlation matrix - rsem-tpm.polya
-          command: ./scripts/run_in_ci.sh python3 analyses/comparative-RNASeq-analysis/01-correlation-matrix.py ../../data/pbta-gene-expression-rsem-tpm.polya.rds --clinical-path ../../data/pbta-histologies.tsv --qc-manifest-path ../../data/pbta-mend-qc-manifest.tsv --qc-results-path ../../data/pbta-mend-qc-results.tar.gz --prefix rsem-tpm-polya- --verbose
+      #- run:
+      #    name: Comparative RNASeq - generate correlation matrix - rsem-tpm.polya
+      #    command: ./scripts/run_in_ci.sh python3 analyses/comparative-RNASeq-analysis/01-correlation-matrix.py ../../data/pbta-gene-expression-rsem-tpm.polya.rds --clinical-path ../../data/pbta-histologies.tsv --qc-manifest-path ../../data/pbta-mend-qc-manifest.tsv --qc-results-path ../../data/pbta-mend-qc-results.tar.gz --prefix rsem-tpm-polya- --verbose
 
       - run:
           name: Comparative RNASeq - generate correlation matrix - rsem-tpm.stranded

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,9 +176,9 @@ jobs:
           name: Oncoprint plotting
           command: ./scripts/run_in_ci.sh bash "analyses/oncoprint-landscape/run-oncoprint.sh"
 
-      - run:
-          name: GISTIC Plots
-          command: ./scripts/run_in_ci.sh Rscript -e "rmarkdown::render('analyses/cnv-chrom-plot/gistic_plot.Rmd', clean = TRUE)"
+      #- run:
+      #    name: GISTIC Plots
+      #    command: ./scripts/run_in_ci.sh Rscript -e "rmarkdown::render('analyses/cnv-chrom-plot/gistic_plot.Rmd', clean = TRUE)"
 
       - run:
           name: CN Status Heatmap

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,9 +164,9 @@ jobs:
       #    name: Comparative RNASeq - generate correlation matrix - rsem-tpm.stranded
       #    command: ./scripts/run_in_ci.sh python3 analyses/comparative-RNASeq-analysis/01-correlation-matrix.py ../../data/pbta-gene-expression-rsem-tpm.stranded.rds --clinical-path ../../data/pbta-histologies.tsv --qc-manifest-path ../../data/pbta-mend-qc-manifest.tsv --qc-results-path ../../data/pbta-mend-qc-results.tar.gz --prefix rsem-tpm-stranded- --verbose
 
-      - run:
-          name: Comparative RNASeq - generate thresholds and outliers - rsem-tpm.stranded
-          command: ./scripts/run_in_ci.sh python3 analyses/comparative-RNASeq-analysis/02-thresholds-and-outliers.py --prefix rsem-tpm-stranded- --results results --verbose
+      #- run:
+      #    name: Comparative RNASeq - generate thresholds and outliers - rsem-tpm.stranded
+      #    command: ./scripts/run_in_ci.sh python3 analyses/comparative-RNASeq-analysis/02-thresholds-and-outliers.py --prefix rsem-tpm-stranded- --results results --verbose
 
       - run:
           name: Process SV file

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,9 +156,9 @@ jobs:
           name: Survival analysis
           command: ./scripts/run_in_ci.sh Rscript -e "rmarkdown::render('analyses/survival-analysis/survival-analysis_template.Rmd', params = list(plot_ci = FALSE), clean = TRUE)"
 
-      - run:
-          name: Comparative RNASeq - generate correlation matrix - rsem-tpm.polya
-          command: ./scripts/run_in_ci.sh python3 analyses/comparative-RNASeq-analysis/01-correlation-matrix.py ../../data/pbta-gene-expression-rsem-tpm.polya.rds --clinical-path ../../data/pbta-histologies.tsv --qc-manifest-path ../../data/pbta-mend-qc-manifest.tsv --qc-results-path ../../data/pbta-mend-qc-results.tar.gz --prefix rsem-tpm-polya- --verbose
+      #- run:
+      #    name: Comparative RNASeq - generate correlation matrix - rsem-tpm.polya
+      #    command: ./scripts/run_in_ci.sh python3 analyses/comparative-RNASeq-analysis/01-correlation-matrix.py ../../data/pbta-gene-expression-rsem-tpm.polya.rds --clinical-path ../../data/pbta-histologies.tsv --qc-manifest-path ../../data/pbta-mend-qc-manifest.tsv --qc-results-path ../../data/pbta-mend-qc-results.tar.gz --prefix rsem-tpm-polya- --verbose
 
       #- run:
       #    name: Comparative RNASeq - generate correlation matrix - rsem-tpm.stranded

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,9 +52,9 @@ jobs:
           name: Molecular subtyping Chordoma
           command: OPENPBTA_SUBSET=0 ./scripts/run_in_ci.sh bash analyses/molecular-subtyping-chordoma/run-molecular-subtyping-chordoma.sh
 
-      - run:
-          name: Molecular subtyping - Ependymoma
-          command: OPENPBTA_SUBSET=0 ./scripts/run_in_ci.sh bash analyses/molecular-subtyping-EPN/run-molecular-subtyping-EPN.sh
+      #- run:
+      #    name: Molecular subtyping - Ependymoma
+      #    command: OPENPBTA_SUBSET=0 ./scripts/run_in_ci.sh bash analyses/molecular-subtyping-EPN/run-molecular-subtyping-EPN.sh
 
       - run:
           name: Molecular Subtyping - LGAT

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,13 +156,13 @@ jobs:
           name: Survival analysis
           command: ./scripts/run_in_ci.sh Rscript -e "rmarkdown::render('analyses/survival-analysis/survival-analysis_template.Rmd', params = list(plot_ci = FALSE), clean = TRUE)"
 
-      #- run:
-      #    name: Comparative RNASeq - generate correlation matrix - rsem-tpm.polya
-      #    command: ./scripts/run_in_ci.sh python3 analyses/comparative-RNASeq-analysis/01-correlation-matrix.py ../../data/pbta-gene-expression-rsem-tpm.polya.rds --clinical-path ../../data/pbta-histologies.tsv --qc-manifest-path ../../data/pbta-mend-qc-manifest.tsv --qc-results-path ../../data/pbta-mend-qc-results.tar.gz --prefix rsem-tpm-polya- --verbose
-
       - run:
-          name: Comparative RNASeq - generate correlation matrix - rsem-tpm.stranded
-          command: ./scripts/run_in_ci.sh python3 analyses/comparative-RNASeq-analysis/01-correlation-matrix.py ../../data/pbta-gene-expression-rsem-tpm.stranded.rds --clinical-path ../../data/pbta-histologies.tsv --qc-manifest-path ../../data/pbta-mend-qc-manifest.tsv --qc-results-path ../../data/pbta-mend-qc-results.tar.gz --prefix rsem-tpm-stranded- --verbose
+          name: Comparative RNASeq - generate correlation matrix - rsem-tpm.polya
+          command: ./scripts/run_in_ci.sh python3 analyses/comparative-RNASeq-analysis/01-correlation-matrix.py ../../data/pbta-gene-expression-rsem-tpm.polya.rds --clinical-path ../../data/pbta-histologies.tsv --qc-manifest-path ../../data/pbta-mend-qc-manifest.tsv --qc-results-path ../../data/pbta-mend-qc-results.tar.gz --prefix rsem-tpm-polya- --verbose
+
+      #- run:
+      #    name: Comparative RNASeq - generate correlation matrix - rsem-tpm.stranded
+      #    command: ./scripts/run_in_ci.sh python3 analyses/comparative-RNASeq-analysis/01-correlation-matrix.py ../../data/pbta-gene-expression-rsem-tpm.stranded.rds --clinical-path ../../data/pbta-histologies.tsv --qc-manifest-path ../../data/pbta-mend-qc-manifest.tsv --qc-results-path ../../data/pbta-mend-qc-results.tar.gz --prefix rsem-tpm-stranded- --verbose
 
       - run:
           name: Comparative RNASeq - generate thresholds and outliers - rsem-tpm.stranded

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,9 +44,9 @@ jobs:
           name: Molecular subtyping - Non-MB/Non-ATRT Embryonal tumors
           command: OPENPBTA_SUBSET=0 ./scripts/run_in_ci.sh bash analyses/molecular-subtyping-embryonal/run-embryonal-subtyping.sh
 
-      - run:
-          name: Molecular Subtyping and Plotting - ATRT
-          command:  OPENPBTA_SUBSET=0 ./scripts/run_in_ci.sh bash analyses/molecular-subtyping-ATRT/run-molecular-subtyping-ATRT.sh
+      #- run:
+      #    name: Molecular Subtyping and Plotting - ATRT
+      #    command:  OPENPBTA_SUBSET=0 ./scripts/run_in_ci.sh bash analyses/molecular-subtyping-ATRT/run-molecular-subtyping-ATRT.sh
 
       - run:
           name: Molecular subtyping Chordoma
@@ -68,7 +68,7 @@ jobs:
          name: Molecular Subtyping Neurocytoma
          command: ./scripts/run_in_ci.sh bash analyses/molecular-subtyping-neurocytoma/run_subtyping.sh
 
-     # Commenting this out for now; the code is expected to change 
+     # Commenting this out for now; the code is expected to change
      # - run:
      #    name: Molecular Subtyping - Compile and incorporate pathology feedback
      #    command: OPENPBTA_TESTING=1 ./scripts/run_in_ci.sh bash analyses/molecular-subtyping-pathology/run-subtyping-aggregation.sh
@@ -137,7 +137,7 @@ jobs:
           command: OPENPBTA_ALL=0 ./scripts/run_in_ci.sh bash analyses/interaction-plots/01-create-interaction-plots.sh
 
       - run:
-          name: Mutational Signatures 
+          name: Mutational Signatures
           command: OPENPBTA_QUICK_MUTSIGS=1 ./scripts/run_in_ci.sh bash analyses/mutational-signatures/run_mutational_signatures.sh
 
       - run:
@@ -224,7 +224,7 @@ jobs:
       - run:
           name: Exploration of nonsynonymous filter
           command: ./scripts/run_in_ci.sh bash analyses/snv-callers/explore_variant_classifications/run_explorations.sh
-          
+
       # This analysis was used to explore the TCGA PBTA data when the BED files used to calculate TCGA
       # were incorrect https://github.com/AlexsLemonade/OpenPBTA-analysis/issues/568
       #- run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,9 +132,9 @@ jobs:
           name: Independent samples
           command: ./scripts/run_in_ci.sh bash analyses/independent-samples/run-independent-samples.sh
 
-      - run:
-          name: Interaction plot
-          command: OPENPBTA_ALL=0 ./scripts/run_in_ci.sh bash analyses/interaction-plots/01-create-interaction-plots.sh
+      #- run:
+      #    name: Interaction plot
+      #    command: OPENPBTA_ALL=0 ./scripts/run_in_ci.sh bash analyses/interaction-plots/01-create-interaction-plots.sh
 
       - run:
           name: Mutational Signatures


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

### Purpose/implementation Section

The v18 subset files have been added to S3. Now we need to know what's broken. I'm going to comment out broken modules and find things and record them here. 


### A running list of broken modules:

So far...


- `molecular-subtyping-ATRT/01-ATRT-molecular-subtyping-data-prep.Rmd` has this error (which looks label related and I'll comment more as I find out):
```
See spec(...) for full column specifications.
Error in labels_mat[, i] : subscript out of bounds
Calls: <Anonymous> ... Legend -> discrete_legend_body -> do.call -> lapply
In addition: Warning message:
In matrix(1:(nrow * ncol), nrow = nrow, ncol = ncol, byrow = by_row) :
  data length exceeds size of matrix
Execution halted
```

- `molecular-subtyping-EPN/02_ependymoma_generate_all_data.py` doesn't recognize the new biospecimen ID. See this [error here](https://app.circleci.com/pipelines/github/AlexsLemonade/OpenPBTA-analysis/4711/workflows/f016e8ca-d982-4a12-9345-8e36e7913418/jobs/5243). 
```
  File "pandas/_libs/hashtable_class_helper.pxi", line 1607, in pandas._libs.hashtable.PyObjectHashTable.get_item
  File "pandas/_libs/hashtable_class_helper.pxi", line 1614, in pandas._libs.hashtable.PyObjectHashTable.get_item
KeyError: ('BS_EVCAC3NH', 'occurred at index 90')
```

- `interaction-plots/01-create-interaction-plots.sh` has some troubles with this `combn` function. This is in the `scripts/coocur_functiions.R`. Line 94. See this [error here](https://app.circleci.com/pipelines/github/AlexsLemonade/OpenPBTA-analysis/4712/workflows/8cf84b0a-6706-4f88-b159-cfaf3c29b74e/jobs/5244). 
```
Error in combn(genes, m = 2) : n < m
Calls: coocurrence -> t -> combn
Execution halted
```

-  None of the Comparative RNA-seq analyses are running. The first error was: `analyses/comparative-RNASeq-analysis/01-correlation-matrix.py`my suspicions is that the others are dependent on the first one completing so I'm not sure if they also have separate issues. See this [error here](https://app.circleci.com/pipelines/github/AlexsLemonade/OpenPBTA-analysis/4713/workflows/77db5ed6-603f-43b0-af49-9de84a96e63f/jobs/5245).
```
File "analyses/comparative-RNASeq-analysis/01-correlation-matrix.py", line 30, in extract_sample_qc_status
    status = qc_file_handle.readlines()[1][-5:-1].decode("utf-8")
IndexError: list index out of range
```

- gistic plots are not running from an error in `analyses/cnv-chrom-plot/gistic_plot.Rmd`. See the full [error here](https://app.circleci.com/pipelines/github/AlexsLemonade/OpenPBTA-analysis/4717/workflows/0b1743e9-f22a-4048-8b47-67662dcb842a/jobs/5249). 
```
Quitting from lines 157-213 (gistic_plot.Rmd) 
Error in .Call2("solve_user_SEW0", start, end, width, PACKAGE = "IRanges") : 
  In range 1: at least two out of 'start', 'end', and 'width', must
  be supplied.
Calls: <Anonymous> ... <Anonymous> -> <Anonymous> -> solveUserSEW0 -> .Call2
```