### PR TITLE
Update top_n logic 

### DIFF
--- a/analyses/oncoprint-landscape/02-plot-oncoprint.R
+++ b/analyses/oncoprint-landscape/02-plot-oncoprint.R
@@ -98,7 +98,7 @@ option_list <- list(
   optparse::make_option(
     c("-n", "--top_n"),
     type = "integer",
-    default = NULL,
+    default = 25,
     help = "optional `n` to display top n genes based on count of mutations"
   ),
   optparse::make_option(
@@ -245,8 +245,9 @@ maf_object <- prepare_maf_object(
 # https://github.com/marislab/create-pptc-pdx-oncoprints/blob/master/R/create-complexheat-oncoprint-revision.R
 
 # Subset `maf_object` for histology-specific goi list
-if (!is.null(opt$goi_list)) {
-  maf_object = subsetMaf(
+if (all(!is.null(opt$goi_list), !is.null(opt$top_n))) {
+  
+  maf_object <- subsetMaf(
     maf = maf_object,
     tsb = metadata$Tumor_Sample_Barcode,
     genes = goi_list,
@@ -260,16 +261,13 @@ if (!is.null(opt$goi_list)) {
   goi_ordered <-
     gene_sum[order(gene_sum$AlteredSamples, decreasing = T),]
   
-  if (!is.null(opt$top_n)) {
-    
-    # Select top `n` genes if the argument is provided
-    top_n <- ifelse(nrow(gene_sum) < opt$top_n, nrow(gene_sum), opt$top_n)
-    
-    goi_list <- goi_ordered[1:top_n,]
-    
-  }
+  # Select top `n` genes if the argument is provided
+  top_n <- ifelse(nrow(gene_sum) < opt$top_n, nrow(gene_sum), opt$top_n)
+  
+  goi_list <- goi_ordered[1:top_n, Hugo_Symbol]
   
 }
+
 #### Plot and Save Oncoprint --------------------------------------------------
 
 # Given a maf object, plot an oncoprint of the variants in the
@@ -281,10 +279,11 @@ png(
   units = "cm",
   res = 300
 )
+
 oncoplot(
   maf_object,
   clinicalFeatures = "display_group",
-  genes = goi_list$Hugo_Symbol,
+  genes = goi_list,
   logColBar = TRUE,
   sortByAnnotation = TRUE,
   showTumorSampleBarcodes = TRUE,
@@ -295,7 +294,8 @@ oncoplot(
   colors = oncoprint_col_palette,
   annotationColor = annotation_colors,
   bgCol = "#F5F5F5",
-  top = 25
+  top = opt$top_n
 )
+
 dev.off()
 


### PR DESCRIPTION
Related to #1046 - updates logic as discussed in the thread https://github.com/AlexsLemonade/OpenPBTA-analysis/pull/1046#discussion_r626068485

The way it was written if someone passed `top_n` but not a GOI list, the top argument would not be respected because `25` was hardcoded. Also, if someone passed a GOI file but no `top_n`, I believe this would have been referencing a `Hugo_Symbol` column that may not have existed.