### PR TITLE
Switch CircleCI image to Ubuntu 20.04

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,13 +3,11 @@ jobs:
   run_analyses:
     machine:
       image: ubuntu-2004:202201-02
+      docker_layer_caching: true
     resource_class: large
     working_directory: ~/OpenPBTA-analysis
     steps:
       - checkout
-      
-      - setup_remote_docker:
-          docker_layer_caching: true
 
       - run:
           name: Data Download

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,11 +3,13 @@ jobs:
   run_analyses:
     machine:
       image: ubuntu-2004:202201-02
-      docker_layer_caching: true
     resource_class: large
     working_directory: ~/OpenPBTA-analysis
     steps:
       - checkout
+      
+      - setup_remote_docker:
+          docker_layer_caching: true
 
       - run:
           name: Data Download

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2
 jobs:
   run_analyses:
     machine:
+      image: ubuntu-2004:202201-02
       docker_layer_caching: true
     resource_class: large
     working_directory: ~/OpenPBTA-analysis


### PR DESCRIPTION
Since we don't specify an image, we were using a Ubuntu 14.04-based image that's about to be deprecated. This should use a Ubuntu 20.04-based image. I don't foresee any issues, but we shall find out!

More context:

* https://circleci.com/blog/ubuntu-14-16-image-deprecation/
* https://circleci.com/docs/2.0/images/linux-vm/14.04-to-20.04-migration/