### PR TITLE
Remove duplicated CI step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,10 +167,6 @@ jobs:
           command: OPENPBTA_TESTING=1 ./scripts/run_in_ci.sh bash analyses/focal-cn-file-preparation/run-prepare-cn.sh
 
       - run:
-          name: Survival analysis
-          command: ./scripts/run_in_ci.sh Rscript -e "rmarkdown::render('analyses/survival-analysis/survival-analysis_template.Rmd', params = list(plot_ci = FALSE), clean = TRUE)"
-
-      - run:
           name: Comparative RNASeq 
           command: ./scripts/run_in_ci.sh bash analyses/comparative-RNASeq-analysis/run-comparative-RNAseq.sh
 
@@ -275,7 +271,7 @@ jobs:
     #      command: ./scripts/run_in_ci.sh Rscript -e "rmarkdown::render('analyses/tmb-compare/compare-tmb-calculations.Rmd', clean = TRUE)"
 
       - run:
-          name: Run survival plots
+          name: Survival analysis
           command: ./scripts/run_in_ci.sh bash analyses/survival-analysis/run_survival.sh
 
       - run:


### PR DESCRIPTION
CI had two lines for survival analysis:

+ One line _just_ to render the template notebook
+ One line to run the full module

However, the template notebook is also included when running the full module. Therefore it does not need to be run on its own (aka twice). I removed CI line that renders the template notebook.