### PR TITLE
v22 CI fixes

### DIFF
--- a/analyses/create-subset-files/01-get_biospecimen_identifiers.R
+++ b/analyses/create-subset-files/01-get_biospecimen_identifiers.R
@@ -57,7 +57,7 @@ get_biospecimen_ids <- function(filename, id_mapping_df) {
     # 'Tumor_Sample_Barcode'
     # if the files have consensus in the name, the first line of the file does
     # not contain MAF version information
-    if (grepl("consensus|hotspots", filename)) {
+    if (grepl("consensus|hotspots|tmb", filename)) {
       snv_file <- data.table::fread(filename, data.table = FALSE)
     } else {
       snv_file <- data.table::fread(filename,
@@ -134,7 +134,7 @@ option_list <- list(
   make_option(
     c("-r", "--supported_string"),
     type = "character",
-    default = "pbta-snv|pbta-cnv|pbta-fusion|pbta-isoform|pbta-sv|pbta-gene|consensus_seg_annotated",
+    default = "pbta-snv|pbta-cnv|pbta-fusion|pbta-isoform|pbta-sv|pbta-gene|consensus_seg_annotated|consensus_seg_with_status",
     help = "string for pattern matching used to subset to only supported files"
   ),
   make_option(

--- a/analyses/create-subset-files/02-subset_files.R
+++ b/analyses/create-subset-files/02-subset_files.R
@@ -101,7 +101,7 @@ subset_files <- function(filename, biospecimen_ids, output_directory) {
     annotated_cn_file %>%
       dplyr::filter(biospecimen_id %in% biospecimen_ids) %>%
       readr::write_tsv(output_file)
-    else if (grepl("consensus_seg_with_status", filename)) {
+  } else if (grepl("consensus_seg_with_status", filename)) {
       cn_seg_status_file <- readr::read_tsv(filename)
       cn_seg_status_file %>%
         dplyr::filter(Kids_First_Biospecimen_ID %in% biospecimen_ids) %>%

--- a/analyses/create-subset-files/02-subset_files.R
+++ b/analyses/create-subset-files/02-subset_files.R
@@ -69,7 +69,7 @@ subset_files <- function(filename, biospecimen_ids, output_directory) {
   # filtering strategy depends on the file type, mostly because how the sample
   # IDs change based on the file type -- that's why this logic is required
   if (grepl("pbta-snv", filename)) {
-    if (grepl("consensus-mutation|hotspots", filename)) {
+    if (grepl("consensus-mutation|hotspots|tmb", filename)) {
       snv_file <- data.table::fread(filename, data.table = FALSE)
       snv_file %>%
         dplyr::filter(Tumor_Sample_Barcode %in% biospecimen_ids) %>%

--- a/analyses/create-subset-files/create_subset_files.sh
+++ b/analyses/create-subset-files/create_subset_files.sh
@@ -5,9 +5,6 @@
 set -e
 set -o pipefail
 
-# Set the working directory to the directory of this file
-cd "$(dirname "${BASH_SOURCE[0]}")"
-
 # Set defaults for release and biospecimen file name
 BIOSPECIMEN_FILE=${BIOSPECIMEN_FILE:-biospecimen_ids_for_subset.RDS}
 RELEASE=${RELEASE:-release-v22-20220505}
@@ -16,7 +13,7 @@ NUM_MATCHED=${NUM_MATCHED:-15}
 # This option controls whether or not the two larger MAF files are skipped as
 # part of subsetting -- the idea is that setting RUN_LOCAL=1 will allow for
 # local testing
-RUN_LOCAL=${RUN_LOCAL:-1}
+RUN_LOCAL=${RUN_LOCAL:-0}
 
 # Use SKIP_SUBSETTING=1 to skip the subsetting steps and only copy full files
 # and generate a new md5sum.txt file - this can be useful if the only files

--- a/analyses/create-subset-files/create_subset_files.sh
+++ b/analyses/create-subset-files/create_subset_files.sh
@@ -5,9 +5,12 @@
 set -e
 set -o pipefail
 
+# Set the working directory to the directory of this file
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
 # Set defaults for release and biospecimen file name
 BIOSPECIMEN_FILE=${BIOSPECIMEN_FILE:-biospecimen_ids_for_subset.RDS}
-RELEASE=${RELEASE:-release-v21-20210820}
+RELEASE=${RELEASE:-release-v22-20220505}
 NUM_MATCHED=${NUM_MATCHED:-15}
 
 # This option controls whether or not the two larger MAF files are skipped as

--- a/analyses/create-subset-files/create_subset_files.sh
+++ b/analyses/create-subset-files/create_subset_files.sh
@@ -31,6 +31,8 @@ cd "$script_directory" || exit
 # generated via these scripts
 FULL_DIRECTORY=../../data/$RELEASE
 SUBSET_DIRECTORY=../../data/testing/$RELEASE
+# If run subsetting only, we need to make this directory
+mkdir -p $SUBSET_DIRECTORY
 
 #### generate subset files -----------------------------------------------------
 


### PR DESCRIPTION
The problem was that we were skipping the header of TMB files, which meant we did not have any participant IDs associated with those files. Once we got to the `intersect` step here: https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/analyses/create-subset-files/01-get_biospecimen_identifiers.R#L279-L280

We had no participant IDs, and similarly, we get back no participant IDs here: https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/addac5b6d1b1a0003592a03e268e8877b7ca4d40/analyses/create-subset-files/01-get_biospecimen_identifiers.R#L283

So when we attempted to sample `polya_for_subset` here: https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/addac5b6d1b1a0003592a03e268e8877b7ca4d40/analyses/create-subset-files/01-get_biospecimen_identifiers.R#L288

It threw the error noted here https://github.com/AlexsLemonade/OpenPBTA-analysis/issues/1426#issuecomment-1143943704

