### PR TITLE
Split out analyses from figures script

### DIFF
--- a/figures/generate-figures.sh
+++ b/figures/generate-figures.sh
@@ -33,58 +33,6 @@ Rscript --vanilla scripts/color_palettes.R
 Rscript -e "rmarkdown::render('mapping-histology-labels.Rmd', clean = TRUE, params = list(release = 'release-v21-20210820'))"
 
 
-##### Run all analysis modules required for figures ---------------------------------------
-
-# Run modules that cannot be run locally due to memory requirements
-if [ "$RUN_LOCAL" -lt "1" ]; then
-  bash ${analyses_dir}/focal-cn-file-preparation/run-prepare-cn.sh       # Figures 2 and S3
-  bash ${analyses_dir}/snv-callers/run_caller_consensus_analysis-pbta.sh # Figure S2
-  bash ${analyses_dir}/snv-callers/run_caller_consensus_analysis-tcga.sh # Figure S2
-  bash ${analyses_dir}/copy_number_consensus_call/run_consensus_call.sh  # Figure S3 (heatmap)
-fi
-
-# Run the `oncoprint-landscape` module shell script, for Figure 2 and S3
-bash ${analyses_dir}/oncoprint-landscape/run-oncoprint.sh
-
-# Run the interaction plots script for Figures 3 and S3
-bash ${analyses_dir}/interaction-plots/01-create-interaction-plots.sh
-
-
-# Run the chromothripsis module, which requires the chromosomal-instability module, for Figure 3
-bash ${analyses_dir}/chromosomal-instability/run_breakpoint_analysis.sh
-bash ${analyses_dir}/chromothripsis/run-chromothripsis.sh
-
-# Run the mutational-signatures module for Figures 3 and S4
-# We only run the part of the module used in the manuscript (i.e., not de novo)
-OPENPBTA_CNS_FIT_ONLY=1 bash ${analyses_dir}/mutational-signatures/run_mutational_signatures.sh
-
-# Run the collapse-rnaseq module, which is needed for telomerase, immune deconvolution, and GSVA modules
-OPENPBTA_TP53_FIGURES=1 bash ${analyses_dir}/collapse-rnaseq/run-collapse-rnaseq.sh 
-
-# Run the telomerase activity prediction script, for Figures 4 and S5
-# TODO: should we actually just run the full module script? I don't do that here since it also re-runs collapse rna seq.
-Rscript --vanilla ${analyses_dir}/telomerase-activity-prediction/01-run-EXTEND.R \
- --input ${analyses_dir}/collapse-rnaseq/results/pbta-gene-expression-rsem-fpkm-collapsed.stranded.rds \
- --output ${analyses_dir}/telomerase-activity-prediction/results/TelomeraseScores_PTBAStranded_FPKM.txt
-
-# Run the tp53 classifier, for Figures 4 and S5
-bash ${analyses_dir}/tp53_nf1_score/run_classifier.sh
-
-# Run the survival module, for Figures 4 and 5
-bash ${analyses_dir}/survival-analysis/run_survival.sh
-
-# Run the dimension reduction module, for Figures 5 and S6
-bash ${analyses_dir}/transcriptomic-dimension-reduction/dimension-reduction-plots.sh
-
-# Run the immune deconvolution module, for Figures 5 and S6
-bash ${analyses_dir}/immune-deconv/run-immune-deconv.sh
-
-# Generate GSVA scores and test for cancer group differences, for Figure 5
-bash ${analyses_dir}/gene-set-enrichment-analysis/run-gsea.sh
-
-
-
-
 ##### Figure 1: Workflow and sample distribution ------------------------------------
 
 # Create directories

--- a/scripts/run-analyses-for-figures.sh
+++ b/scripts/run-analyses-for-figures.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+#
+# Run all analysis modules that are used for manuscript figures
+
+#enviroment settings
+set -e
+set -o pipefail
+
+# If RUN_LOCAL is used, the time-intensive steps are skipped because they cannot
+# be run on a local computer -- the idea is that setting RUN_LOCAL=1 will allow for
+# local testing running/testing of all the other figures
+RUN_LOCAL=${RUN_LOCAL:-0}
+
+# Find current directory based on this script
+WORKDIR=$(dirname "${BASH_SOURCE[0]}")
+cd "$WORKDIR"
+
+# Get base directory of project
+cd ..
+BASEDIR="$(pwd)"
+cd -
+
+analyses_dir="$BASEDIR/analyses"
+
+#################################
+
+# Run modules that cannot be run locally due to memory requirements
+if [ "$RUN_LOCAL" -lt "1" ]; then
+  bash ${analyses_dir}/focal-cn-file-preparation/run-prepare-cn.sh       # Figures 2 and S3
+  bash ${analyses_dir}/snv-callers/run_caller_consensus_analysis-pbta.sh # Figure S2
+  bash ${analyses_dir}/snv-callers/run_caller_consensus_analysis-tcga.sh # Figure S2
+  bash ${analyses_dir}/copy_number_consensus_call/run_consensus_call.sh  # Figure S3 (heatmap)
+fi
+
+# Run the `oncoprint-landscape` module shell script, for Figure 2 and S3
+bash ${analyses_dir}/oncoprint-landscape/run-oncoprint.sh
+
+# Run the interaction plots script for Figures 3 and S3
+bash ${analyses_dir}/interaction-plots/01-create-interaction-plots.sh
+
+
+# Run the chromothripsis module, which requires the chromosomal-instability module, for Figure 3
+bash ${analyses_dir}/chromosomal-instability/run_breakpoint_analysis.sh
+bash ${analyses_dir}/chromothripsis/run-chromothripsis.sh
+
+# Run the mutational-signatures module for Figures 3 and S4
+# We only run the part of the module used in the manuscript (i.e., not de novo)
+OPENPBTA_CNS_FIT_ONLY=1 bash ${analyses_dir}/mutational-signatures/run_mutational_signatures.sh
+
+# Run the collapse-rnaseq module, which is needed for telomerase, immune deconvolution, and GSVA modules
+OPENPBTA_TP53_FIGURES=1 bash ${analyses_dir}/collapse-rnaseq/run-collapse-rnaseq.sh 
+
+# Run the telomerase activity prediction script, for Figures 4 and S5
+Rscript --vanilla ${analyses_dir}/telomerase-activity-prediction/01-run-EXTEND.R \
+ --input ${analyses_dir}/collapse-rnaseq/results/pbta-gene-expression-rsem-fpkm-collapsed.stranded.rds \
+ --output ${analyses_dir}/telomerase-activity-prediction/results/TelomeraseScores_PTBAStranded_FPKM.txt
+
+# Run the tp53 classifier, for Figures 4 and S5
+bash ${analyses_dir}/tp53_nf1_score/run_classifier.sh
+
+# Run the survival module, for Figures 4 and 5
+bash ${analyses_dir}/survival-analysis/run_survival.sh
+
+# Run the dimension reduction module, for Figures 5 and S6
+bash ${analyses_dir}/transcriptomic-dimension-reduction/dimension-reduction-plots.sh
+
+# Run the immune deconvolution module, for Figures 5 and S6
+bash ${analyses_dir}/immune-deconv/run-immune-deconv.sh
+
+# Generate GSVA scores and test for cancer group differences, for Figure 5
+bash ${analyses_dir}/gene-set-enrichment-analysis/run-gsea.sh
+
+


### PR DESCRIPTION
Closes #1455.
**Merge AFTER all boxes are checked in #1455.**

This PR separates out analyses from `figures/generate-figures.sh` into a new script, `scripts/run-analyses-for-figures.sh`. 

Questions for reviewers:
+ Script name ok?
+ Script location ok?
+ Should we also add another script to call the four other ones (see #1455)?