### PR TITLE
Try to fix `workflow_dispatch` trigger in count contributions GHA workflow

### DIFF
--- a/.github/workflows/count-git-contributions.yml
+++ b/.github/workflows/count-git-contributions.yml
@@ -4,9 +4,9 @@ name: cronjob for counting git contributions and filing a PR with results
 # On Wednesdays, we count git contributions
 # But we can also manually trigger this
 on:
-  workflow_dispatch
   schedule:
     - cron: "0 14 * * WED"
+  workflow_dispatch:
 
 jobs:
   file-count-contributions-pr:


### PR DESCRIPTION
The changes in the GHA workflow in #1536 sure did not work. Here I'm trying to make the `workflow_dispatch` trigger work by putting it after the `cron` trigger and using a trailing `:`, which the internet told me is fine (but we'll find out).