### PR TITLE
Fix directory name in count-contributions .gitignore

### DIFF
--- a/analyses/count-contributions/.gitignore
+++ b/analyses/count-contributions/.gitignore
@@ -1,2 +1,2 @@
 # Ignore updated manuscript metadata file
-Results/updated_metadata.yaml
+results/updated_metadata.yaml


### PR DESCRIPTION
This change snuck by me in #1562. It worked as intended on Mac, but not on the Linux image in GHA (see: #1587).