### PR TITLE
Add notebook for authorship TSV and update workflow

### DIFF
--- a/.github/workflows/count-git-contributions.yml
+++ b/.github/workflows/count-git-contributions.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
-          ref: "sjspielman/author_tsv"
+          ref: "master"
           fetch-depth: 0
 
       - name: Configure git

--- a/.github/workflows/count-git-contributions.yml
+++ b/.github/workflows/count-git-contributions.yml
@@ -45,6 +45,13 @@ jobs:
           name: manuscript_metadata
           path: analyses/count-contributions/results/metadata.yaml
 
+      # Upload the author information as an artifact
+      - name: Upload author information TSV artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: author_information
+          path: analyses/count-contributions/author_information.tsv
+
       # Create a pull request with the updated results
       - name: Create PR with updated contribution module
         uses: peter-evans/create-pull-request@v3
@@ -83,9 +90,13 @@ jobs:
           git config --local user.email "actions@github.com"
           git config --local user.name "GitHub Actions"
 
-      # You can not overwrite an existing file with an artifact
-      - name: Remove existing metadata file
+      # Set up directories to be able to receive artifacts
+      # Note, You can not overwrite an existing file with an artifact,
+      #  so this step also removes existing files.
+      - name: Directory setup
         run: |
+          mkdir -p submission_info/
+          rm -f submission_info/author_information.tsv
           rm content/metadata.yaml
 
       - name: Download the metadata artifact
@@ -93,6 +104,14 @@ jobs:
         with:
           name: manuscript_metadata
           path: content
+
+
+      - name: Download the author information artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: author_information
+          path: submission_info
+
 
       # Create a pull request with the updated results
       - name: Create PR with updated manuscript metadata YAML
@@ -112,6 +131,6 @@ jobs:
  
             ### Instruction for reviewers
 
-            Review the updates in `content/metadata.yaml` for accuracy.
+            Review the updates in `content/metadata.yaml` and `submission_info/author_information.tsv` for accuracy.
 
           reviewers: $GITHUB_ACTOR

--- a/.github/workflows/count-git-contributions.yml
+++ b/.github/workflows/count-git-contributions.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
-          ref: "master"
+          ref: "sjspielman/author_tsv"
           fetch-depth: 0
 
       - name: Configure git

--- a/analyses/count-contributions/.gitignore
+++ b/analyses/count-contributions/.gitignore
@@ -2,4 +2,4 @@
 results/metadata.yaml
 
 # Ignore authorship TSV
-results/author_information.tsv
+author_information.tsv

--- a/analyses/count-contributions/.gitignore
+++ b/analyses/count-contributions/.gitignore
@@ -1,2 +1,5 @@
 # Ignore updated manuscript metadata file
 results/metadata.yaml
+
+# Ignore authorship TSV
+results/author_information.tsv

--- a/analyses/count-contributions/04-get-author-information-tsv.Rmd
+++ b/analyses/count-contributions/04-get-author-information-tsv.Rmd
@@ -1,0 +1,104 @@
+---
+title: "Creating a TSV of author information for AlexsLemonade/OpenPBTA-manuscript"
+output: 
+  html_notebook:
+    toc: true
+    toc_float: true
+author: Stephanie Spielman for ALSF CCDL
+date: 2022
+---
+
+```{r setup}
+library(magrittr) # load for piping
+```
+
+
+This notebook parses the `metadata.yaml` file to obtain a TSV of author information relevant for manuscript submission, including:
+
+- Name
+- Affiliation(s)
+- ORCID
+- Email 
+
+
+## Read in metadata 
+
+The previously-run notebook `03-set-authorship-order.Rmd` will have obtained the most recent metadata YAML file, so we can directly read it in and grab the author list.
+
+
+```{r}
+manuscript_metadata <- yaml::read_yaml("metadata.yaml")
+author_list <- manuscript_metadata$author
+```
+
+## Parse the metadata
+
+First, we'll define a function that is useful for parsing fields out of the metadata. 
+This function allows for the fact that some keys may be missing for some authors (e.g. `ORCID` or `email`), and the function will fill these in as `NA`s.
+
+```{r}
+# Function to parse out a given field
+# This function allows us to extract fields
+#  that might missing, which get assigned NA
+extract_yaml_value <- function(x, name) {
+  
+  # If the name is not present, return NA
+  if (!(name %in% names(x))) {
+    return_list <- list(NA)
+    names(return_list) <- name
+    return(return_list)
+  } else {
+    # Process affiliations specifically since there can be >1
+    #  and at least 1 has superscripts that should be removed
+    if (name == "affiliations") {
+      list("affiliations" =
+             paste(x[["affiliations"]], collapse = "; ") %>%
+             # Remove any superscripts
+             stringr::str_replace_all(., "<sup>.+<\\/sup>", "")
+      )
+    } else {
+      # Extract the value directly
+      return(magrittr::extract(x, name))
+    }
+  }
+  
+}
+```
+
+
+Now, we can use this function to parse the metadata into a data frame.
+
+
+```{r}
+
+# Extract info
+author_info <- dplyr::bind_cols(
+ purrr::map_dfr(author_list, extract_yaml_value, "name"),
+ purrr::map_dfr(author_list, extract_yaml_value, "affiliations"),
+ purrr::map_dfr(author_list, extract_yaml_value, "orcid"),
+ purrr::map_dfr(author_list, extract_yaml_value, "email")
+)
+
+
+# Make names titlecase, except ORCID which should be all uppercase
+names(author_info) <- stringr::str_to_title(names(author_info))
+author_info <- dplyr::rename(author_info, ORCID = Orcid)
+```
+
+### Save
+
+And we're ready to save!
+
+```{r}
+readr::write_tsv(
+  author_info,
+  "author_information.tsv"
+)
+```
+
+## Session Info
+
+```{r}
+sessionInfo()
+```
+

--- a/analyses/count-contributions/04-get-author-information.Rmd
+++ b/analyses/count-contributions/04-get-author-information.Rmd
@@ -23,11 +23,13 @@ This notebook parses the `metadata.yaml` file to obtain a TSV of author informat
 
 ## Read in metadata 
 
-The previously-run notebook `03-set-authorship-order.Rmd` will have obtained the most recent metadata YAML file, so we can directly read it in and grab the author list.
+The previously-run notebook `03-set-authorship-order.Rmd` will have created an updated metadata YAML file in `results/metadata.yaml`, so we can directly read it in and grab the author list.
 
 
 ```{r}
-manuscript_metadata <- yaml::read_yaml("metadata.yaml")
+manuscript_metadata <- yaml::read_yaml(
+  file.path("results", "metadata.yaml")
+)
 author_list <- manuscript_metadata$author
 ```
 

--- a/analyses/count-contributions/README.md
+++ b/analyses/count-contributions/README.md
@@ -26,6 +26,10 @@ See the notebook for more details!
 
 The updated metadata YAML file is ignored by this repository, but can be found at `results/metadata.yaml`.
 
+
+* `04-get-author-information.Rmd` which extracts relevant author information (name, email, affiliation, and ORCID) into a TSV for use during manuscript.
+It creates a file `author_information.tsv`, which is ignored by this repository but will be included in the `AlexsLemonade/OpenPBTA-manuscript` repository in `submission_info/` once the GitHub Actions workflow is run.
+
 ### GitHub Actions workflow
 
 To keep these stats reasonably up-to-date, we use a GitHub Actions (GHA) workflow ([`.github/workflows/count-git-contributions.yml`](https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/.github/workflows/count-git-contributions.yml)) to rerun the module every Wednesday at 14:00 UTC.
@@ -34,6 +38,7 @@ The workflow runs `bash run-count-contributions.sh` on the `master` branch and f
 This PR is intended to be reviewed by an organizer for accuracy before merging.
 
 If the author order changes – i.e., the YAML output from `03-set-authorship-order.Rmd` is different from the `master` branch of `AlexsLemonade/OpenPBTA-manuscript` – a pull request will be filed in the manuscript repository.
+The updated author TSV file `author_information.tsv` will be filed as part of this pull request.
 
 The _scheduled_ GHA workflow is the main way we expect the module to be used, but you can also make use of the [`workflow_dispatch`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch)  trigger [in the GitHub browser interface](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow).
 

--- a/analyses/count-contributions/README.md
+++ b/analyses/count-contributions/README.md
@@ -4,7 +4,7 @@
 
 The purpose of this module is to count the git contributions to this repo in two ways:
 
-1. Count the number of analysis modules – directories in `analyses/` that are included in the manuscript, specifically – that individual contributors have authored commits in. 
+1. Count the number of analysis modules – directories in `analyses/` that are included in the manuscript, specifically – that individual contributors have authored commits in.
   You can find that information in `results/module_contribution_counts.tsv` and a _less summarized_ version that lists all contributors to a module in `results/module_contributors.tsv`.
 2. Count the number of commits to the entire repository individual contributors have authored.
 
@@ -13,21 +13,21 @@ The purpose of this module is to count the git contributions to this repo in two
 The shell script `run-count-contributions.sh` runs the following steps:
 
 * `01-count-contributions.sh` which is a shell script that generates intermediate TXT files (in `scratch/count-contributions`) with the output of `git shortlog` and `git log`.
-* `02-format-contributions.Rmd` which turns the output of `git shortlog` and `git log` into readable files. 
-This notebook additionally collapses people that have their contributions divided across multiple names by the logs and is responsible for removing the analysis modules that are not included in the manuscript. 
+* `02-format-contributions.Rmd` which turns the output of `git shortlog` and `git log` into readable files.
+This notebook additionally collapses people that have their contributions divided across multiple names by the logs and is responsible for removing the analysis modules that are not included in the manuscript.
 See the notebook for more details!
 * `03-set-authorship-order.Rmd` which downloads and reads in the current manuscript metadata file (i.e., from `AlexsLemonade/OpenPBTA-manuscript` `master` branch) and sets the author order based on the following criteria (quoting from the notebook itself):
 
 > * The first, last 4 authors, and consortia authors positions are pinned to reflect scholarship and contributor roles that are not captured in the Git history of this repository (e.g., substantive analytical code review, conceptualization, supervision, or project administration).
 > * Manuscript authors that have contributed to the code base for the analysis repository -- specifically the number of analysis modules that were included in the paper that a manuscript author has contributed to -- are then ordered from the second position on in decreasing order.
 > In the case of ties, the order is randomly selected.
-> * Manuscript authors that did not directly contribute to the code base are then randomly ordered. 
+> * Manuscript authors that did not directly contribute to the code base are then randomly ordered.
 > We set a seed directly before that shuffling step, using the year as the seed, to keep a consistent order in future runs if and when the Git contributions change.
 
 The updated metadata YAML file is ignored by this repository, but can be found at `results/metadata.yaml`.
 
 
-* `04-get-author-information.Rmd` which extracts relevant author information (name, email, affiliation, and ORCID) into a TSV for use during manuscript.
+* `04-get-author-information-tsv.Rmd` which extracts relevant author information (name, email, affiliation, and ORCID) into a TSV for use during manuscript.
 It creates a file `author_information.tsv`, which is ignored by this repository but will be included in the `AlexsLemonade/OpenPBTA-manuscript` repository in `submission_info/` once the GitHub Actions workflow is run.
 
 ### GitHub Actions workflow

--- a/analyses/count-contributions/README.md
+++ b/analyses/count-contributions/README.md
@@ -38,7 +38,7 @@ The workflow runs `bash run-count-contributions.sh` on the `master` branch and f
 This PR is intended to be reviewed by an organizer for accuracy before merging.
 
 If the author order changes – i.e., the YAML output from `03-set-authorship-order.Rmd` is different from the `master` branch of `AlexsLemonade/OpenPBTA-manuscript` – a pull request will be filed in the manuscript repository.
-The updated author TSV file `author_information.tsv` will be filed as part of this pull request.
+The updated author TSV file `submission_info/author_information.tsv` will be filed as part of this pull request.
 
 The _scheduled_ GHA workflow is the main way we expect the module to be used, but you can also make use of the [`workflow_dispatch`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch)  trigger [in the GitHub browser interface](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow).
 

--- a/analyses/count-contributions/README.md
+++ b/analyses/count-contributions/README.md
@@ -27,7 +27,7 @@ See the notebook for more details!
 The updated metadata YAML file is ignored by this repository, but can be found at `results/metadata.yaml`.
 
 
-* `04-get-author-information-tsv.Rmd` which extracts relevant author information (name, email, affiliation, and ORCID) into a TSV for use during manuscript.
+* `04-get-author-information.Rmd` which extracts relevant author information (name, email, affiliation, and ORCID) into a TSV for use during manuscript.
 It creates a file `author_information.tsv`, which is ignored by this repository but will be included in the `AlexsLemonade/OpenPBTA-manuscript` repository in `submission_info/` once the GitHub Actions workflow is run.
 
 ### GitHub Actions workflow

--- a/analyses/count-contributions/run-count-contributions.sh
+++ b/analyses/count-contributions/run-count-contributions.sh
@@ -15,3 +15,6 @@ Rscript -e "rmarkdown::render('02-format-contributions.Rmd', clean = TRUE)"
 
 # Run notebook reordering author list to account for git contributions
 Rscript -e "rmarkdown::render('03-set-authorship-order.Rmd', clean = TRUE)"
+
+# Run notebook generating author list as TSV for submission
+Rscript -e "rmarkdown::render('04-get-author-information.Rmd', clean = TRUE)"

--- a/analyses/count-contributions/run-count-contributions.sh
+++ b/analyses/count-contributions/run-count-contributions.sh
@@ -19,4 +19,3 @@ Rscript -e "rmarkdown::render('03-set-authorship-order.Rmd', clean = TRUE)"
 # Run notebook generating author list as TSV for submission
 Rscript -e "rmarkdown::render('04-get-author-information.Rmd', clean = TRUE)"
 
-ls -la .

--- a/analyses/count-contributions/run-count-contributions.sh
+++ b/analyses/count-contributions/run-count-contributions.sh
@@ -18,3 +18,5 @@ Rscript -e "rmarkdown::render('03-set-authorship-order.Rmd', clean = TRUE)"
 
 # Run notebook generating author list as TSV for submission
 Rscript -e "rmarkdown::render('04-get-author-information.Rmd', clean = TRUE)"
+
+ls -la .


### PR DESCRIPTION
This PR replaces https://github.com/AlexsLemonade/OpenPBTA-manuscript/pull/335 and closes https://github.com/AlexsLemonade/OpenPBTA-manuscript/issues/328.

Here, I have updated the `count-contributions` module to include a fourth notebook, `04-get-author-information.Rmd`, which parses `metadata.yaml` to create an author list for submission. Documentation in this module has been updated to reflect this change. I also set this up to ignore the created file, `author_information.tsv`, from _this_ repository, so it should only live in the manuscript repo.

In addition, I updated the metadata workflow to also file `author_information.tsv` to the manuscript repo, to live in a new directory at root called `submission_info/`. 

Evidence of successful workflow - 
https://github.com/AlexsLemonade/OpenPBTA-analysis/pull/1608
https://github.com/AlexsLemonade/OpenPBTA-manuscript/pull/337