### PR TITLE
Add missing middle initial

### DIFF
--- a/analyses/count-contributions/02-format-contributions.Rmd
+++ b/analyses/count-contributions/02-format-contributions.Rmd
@@ -43,7 +43,7 @@ name_recoding <- c(
   jashapiro = "Joshua A. Shapiro",
   `Joshua Shapiro` = "Joshua A. Shapiro",
   Stephanie = "Stephanie J. Spielman",
-  Bailey = "Bailey Farrow",
+  Bailey = "Bailey K. Farrow",
   runjin326 = "Run Jin",
   Mateusz = "Mateusz P. Koptyra",
   tkoganti = "Tejaswi Koganti",


### PR DESCRIPTION
We were having problems with the author list due to this change: https://github.com/AlexsLemonade/OpenPBTA-manuscript/commit/97a20bf3c03e2deefc28e6a7ebd37eb68930eb90

I just added the corresponding change to the R Markdown file. Once this goes in, I will trigger the workflow again.