### PR TITLE
Complete the Zenodo CSV readme

### DIFF
--- a/tables/zenodo-upload/.gitignore
+++ b/tables/zenodo-upload/.gitignore
@@ -1,1 +1,4 @@
 figure-S2a-S2b-S2c-data.csv.gz
+figure-S2a-S2b-S2c-data.csv
+figure-S2d-S2e-S2f-data.csv
+figure-S3c-data.csv

--- a/tables/zenodo-upload/README.md
+++ b/tables/zenodo-upload/README.md
@@ -101,12 +101,8 @@ Where applicable, all tables are ordered by either `sample_id` or `Kids_First_Bi
 
 | Figure Panel | Filename | Brief Description | Notes on Tabular Data |
 |--------|-------------|--------------------|-------------------------|
-|   S2A     |  `figure-S2a-S2b-S2c-data.csv`   | Correlations of mutation VAFs from variant callers for PBTA data   | This compressed file contains data for all three panels S2A, S2B, and S2C. Caution: Uncompressed, this file is ~3.9 GB.|
-|   S2B     |  `figure-S2a-S2b-S2c-data.csv`  | Distributions of mutation VAFs from variant callers for PBTA data  | This compressed file contains data for all three panels S2A, S2B, and S2C. Caution: Uncompressed, this file is ~3.9 GB.   |
-|   S2C     |  `figure-S2a-S2b-S2c-data.csv`  | Upset plot of overlap among variant callers for PBTA data  | This compressed file contains data for all three panels S2A, S2B, and S2C. Caution: Uncompressed, this file is ~3.9 GB.  |
-|   S3D     |   `figure-S2d-S2e-S2f-data.csv`    |  Correlations of mutation VAFs from variant callers for TCGA data       | This compressed file contains data for all three panels S2D, S2E, and S2F. Uncompressed, this file is 13MB.            |
-|   S2E     |   `figure-S2d-S2e-S2f-data.csv`  |  Distributions of mutation VAFs from variant callers for PBTA data         |   This compressed file contains data for all three panels S2D, S2E, and S2F. Uncompressed, this file is 13MB.           |
-|   S2F     |   `figure-S2d-S2e-S2f-data.csv`  | Upset plot of overlap among variant callers for TCGA data    |  This compressed file contains data for all three panels S2D, S2E, and S2F. Uncompressed, this file is 13MB.            |
+|   S2A-C    |  `figure-S2a-S2b-S2c-data.csv`   | Correlations, distributions, and UpSet plot of mutation VAFs from variant callers for PBTA data, respectively   | This compressed file contains data for all three panels S2A, S2B, and S2C. Caution: Uncompressed, this file is ~3.9 GB.|
+|   S3D-F     |   `figure-S2d-S2e-S2f-data.csv`    |  Correlations, distributions, and UpSet of mutation VAFs from variant callers for TCGA data, respectively       | This compressed file contains data for all three panels S2D, S2E, and S2F. Uncompressed, this file is 13MB.            |
 |   S2G     |   `figure-S2g-data.csv`          |  Distributions of VAFs from Lancet calls on PBTA data for tumors with WGS and WXS   |
 |   S2H     |   `figure-S2h-data.csv`         |  Cumulative distribution TMB plots for PBTA cancer groups          |
 |   S2I     |   `figure-S2i-data.csv`         |  Cumulative distribution PBTA plots for TCGA histologies          |

--- a/tables/zenodo-upload/README.md
+++ b/tables/zenodo-upload/README.md
@@ -101,42 +101,42 @@ Where applicable, all tables are ordered by either `sample_id` or `Kids_First_Bi
 
 | Figure Panel | Filename | Brief Description | Notes on Tabular Data |
 |--------|-------------|--------------------|-------------------------|
-|   S2A     |  `figure-S2a-S2b-S2c-data.csv`   |             |
-|   S2B     |  `figure-S2a-S2b-S2c-data.csv`           |             |
-|   S2C     |  `figure-S2a-S2b-S2c-data.csv`           |             |
-|   S3D     |   `figure-S2d-S2e-S2f-data.csv`          |             |
-|   S2E     |   `figure-S2d-S2e-S2f-data.csv`          |             |
-|   S2F     |   `figure-S2d-S2e-S2f-data.csv`            |             |
-|   S2G     |   `figure-S2g-data.csv`          |             |
-|   S2H     |   `figure-S2h-data.csv`         |             |
-|   S2I     |   `figure-S2i-data.csv`         |             |
+|   S2A     |  `figure-S2a-S2b-S2c-data.csv`   | Correlations of mutation VAFs from variant callers for PBTA data   | This compressed file contains data for all three panels S2A, S2B, and S2C. Caution: Uncompressed, this file is ~3.9 GB.|
+|   S2B     |  `figure-S2a-S2b-S2c-data.csv`  | Distributions of mutation VAFs from variant callers for PBTA data  | This compressed file contains data for all three panels S2A, S2B, and S2C. Caution: Uncompressed, this file is ~3.9 GB.   |
+|   S2C     |  `figure-S2a-S2b-S2c-data.csv`  | Upset plot of overlap among variant callers for PBTA data  | This compressed file contains data for all three panels S2A, S2B, and S2C. Caution: Uncompressed, this file is ~3.9 GB.  |
+|   S3D     |   `figure-S2d-S2e-S2f-data.csv`    |  Correlations of mutation VAFs from variant callers for TCGA data       | This compressed file contains data for all three panels S2D, S2E, and S2F. Uncompressed, this file is 13MB.            |
+|   S2E     |   `figure-S2d-S2e-S2f-data.csv`  |  Distributions of mutation VAFs from variant callers for PBTA data         |   This compressed file contains data for all three panels S2D, S2E, and S2F. Uncompressed, this file is 13MB.           |
+|   S2F     |   `figure-S2d-S2e-S2f-data.csv`  | Upset plot of overlap among variant callers for TCGA data    |  This compressed file contains data for all three panels S2D, S2E, and S2F. Uncompressed, this file is 13MB.            |
+|   S2G     |   `figure-S2g-data.csv`          |  Distributions of VAFs from Lancet calls on PBTA data for tumors with WGS and WXS   |
+|   S2H     |   `figure-S2h-data.csv`         |  Cumulative distribution TMB plots for PBTA cancer groups          |
+|   S2I     |   `figure-S2i-data.csv`         |  Cumulative distribution PBTA plots for TCGA histologies          |
 
 #### Figure S3
 
 | Figure Panel | Filename | Brief Description | Notes on Tabular Data |
 |--------|-------------|--------------------|-------------------------|
-|   S3A     |    `figure-S3a-data.csv`         |             |
-|   S3B     |    `figure-S3b-data.csv`          |             |
-|   S3C     |    `figure-S3c-data.csv.gz`          |             |
-|   S3D     |    `figure-S3d-data.csv`          |             |
-|   S3E     |    `figure-S3e-data.csv`          |             |
+|   S3A     |    `figure-S3a-data.csv`         |   Violin plots of tumor purity by cancer group          |
+|   S3B     |    `figure-S3b-data.csv`          |  Oncoprint summarizing rare CNS tumor alterations across samples for top mutated genes    |
+|   S3C     |    `figure-S3c-data.csv.gz`       | Genome-wide plot of CNV alterations for each sample, grouped by broad histology  |   This file is compressed; uncompressed, this file is ~15 MB.      |
+|   S3D     |    `figure-S3d-data.csv`          | Box plots of SNV breaks across number of chromothripsis regions            |
+|   S3E     |    `figure-S3e-data.csv`          | Box plots of CNV breaks across number of chromothripsis regions            |
 
 
 #### Figure S4
 
 | Figure Panel | Filename | Brief Description | Notes on Tabular Data |
 |--------|-------------|--------------------|-------------------------|
-|   S4A     |   `figure-S4a-data.csv`           |             |
-|   S4B     |   `figure-S4b-data.csv`           |             |
+|   S4A     |   `figure-S4a-data.csv`           |  Sample-specific signature weights for 8 adult CNS-specific RefSig mutational signatures           |
+|   S4B     |   `figure-S4b-data.csv`           |   RefSig Signature 1 weights across cancer groups by phrase of therapy          |
 
 
 #### Figure S5
 
 | Figure Panel | Filename | Brief Description | Notes on Tabular Data |
 |--------|-------------|--------------------|-------------------------|
-|   S5A     |  `figure-S5a-data.csv`            |             |
-|   S5B     |  `figure-S5b-data.csv`            |             |
-|   S5C     |  `figure-S5c-data.csv`            |             |
+|   S5A     |  `figure-S5a-data.csv`            |  ROC curve for _TP53_ classifier run on poly-A RNA-Seq samples           |
+|   S5B     |  `figure-S5b-data.csv`            |  Correlation of _TP53_ classifier score with _TERT_ expression (FPKM)           |
+|   S5C     |  `figure-S5c-data.csv`            |  Correlation of _TP53_ classifier score with _TERC_ expression (FPKM)           |           |
 
 
 
@@ -144,27 +144,27 @@ Where applicable, all tables are ordered by either `sample_id` or `Kids_First_Bi
 
 | Figure Panel | Filename | Brief Description | Notes on Tabular Data |
 |--------|-------------|--------------------|-------------------------|
-|   S6A     |   `figure-S6a-data.csv`          |             |
-|   S6B     |   `figure-S6b-data.csv`          |             |
-|   S6C     |   `figure-S6c-data.csv`          |             |
-|   S6D     |   `figure-S6d-data.csv`          |             |
-|   S6E     |   `figure-S6e-data.csv`          |             |
-|   S6F     |   `figure-S6f-data.csv`          |             |
+|   S6A     |   `figure-S6a-data.csv`          |  UMAP of stranded RNA-Seq samples, with medulloblastoma molecular subtypes emphasized           |
+|   S6B     |   `figure-S6b-data.csv`          |  UMAP of stranded RNA-Seq samples, with ependymoma molecular subtypes emphasized           |
+|   S6C     |   `figure-S6c-data.csv`          |   UMAP of stranded RNA-Seq samples, with low-grade glioma molecular subtypes emphasized          |
+|   S6D     |   `figure-S6d-data.csv`          |  UMAP of stranded RNA-Seq samples, with high-grade glioma molecular subtypes emphasized            |
+|   S6E     |   `figure-S6e-data.csv`          |   quanTIseq-estimated immune cell fractions in histologies with >=3 molecular subtypes         |
+|   S6F     |   `figure-S6f-data.csv`          |  Ratio of CD8+/CD4+ T-cell fractions in histologies with >=3 molecular subtypes             |
 
 
 #### Figure S7
 
 | Figure Panel | Filename | Brief Description | Notes on Tabular Data |
 |--------|-------------|--------------------|-------------------------|
-|   S7A     |   `figure-7a-data.csv`          |             |
-|   S7B     |   `figure-7b-data.csv`            |             |
-|   S7C     |   `figure-7c-data.csv`           |             |
-|   S7D     |   `figure-7d-data.csv`           |             |
-|   S7E     |   `figure-7e-data.csv`           |             |
-|   S7F     |   `figure-7f-data.csv`           |             |
-|   S7G     |   `figure-7g-data.csv`           |             |
-|   S7H     |   `figure-7h-data.csv`           |             |
-|   S7I     |   `figure-7i-data.csv`           |             |
+|   S7A     |   `figure-7a-data.csv`           |  Counts of RNA-Seq samples across cancer groups colored by library preparation method           |
+|   S7B     |   `figure-7b-data.csv`           |   UMAP of all RNA-Seq samples, colored by cancer group, with shapes indicating library preparation method           |
+|   S7C     |   `figure-7c-data.csv`           |  UMAP of stranded RNA-Seq samples, colored by cancer group, with shapes indicating sequencing center            |
+|   S7D     |   `figure-7d-data.csv`           |   ROC curve for TP53 classifier run on stranded RNA-Seq data, considering only tumors with high tumor purity     | High tumor purity is defined as having a tumor purity >= median of the tumor's respective cancer group. <br> This figure corresponds to 4A in the manuscript.      |
+|   S7E     |   `figure-7e-data.csv`           |  Violin/strip plots of TP53 scores across TP53 alteration status, considering only tumors with high tumor purity            | High tumor purity is defined as having a tumor purity >= median of the tumor's respective cancer group. <br> This figure corresponds to 4B in the manuscript.           |
+|   S7F     |   `figure-7f-data.csv`           | Violin/strip plots of TP53 expression [log(FPKM)] across TP53 alteration status, considering only tumors with high tumor purity             |   High tumor purity is defined as having a tumor purity >= median of the tumor's respective cancer group. <br> This figure corresponds to 4C in the manuscript.         |
+|   S7G     |   `figure-7g-data.csv`           |  UMAP of tumors colored by broad histology, considering only tumors with high tumor purity            |  High tumor purity is defined as having a tumor purity >= median of the tumor's respective cancer group. <br> This figure corresponds to 5A in the manuscript.          |
+|   S7H     |   `figure-7h-data.csv`           |  Box/strip plots of quanTIseq scores across cancer groups, considering only tumors with high tumor purity           |  High tumor purity is defined as having a tumor purity >= median of the tumor's respective cancer group. <br> This figure corresponds to 5C in the manuscript.           |
+|   S7I     |   `figure-7i-data.csv`           |  Box/strip plots of TP53 scores and telomerase scores across cancer groups, considering only tumors with high tumor purity       | High tumor purity is defined as having a tumor purity >= median of the tumor's respective cancer group. <br> This figure corresponds to 4D in the manuscript.          |
 
 
 ## Molecular Alterations
@@ -199,4 +199,4 @@ The alterations for a gene are the union of alterations detected in biospecimens
 * `germline_sex_estimate` is only available for `sample_id`-`composition` pairs that were assayed with WGS.
 * In two instances, multiple RNA biospecimens map to the sample `sample_id`-`composition` pair, and only one RNA biospecimen was assigned the `germline_sex_estimate` derived from the WGS data.
 We only included the non-missing values in these rows.
-The `sample_id` impacted are `7316-161` and `7316-85`.
+The `sample_id`s impacted are `7316-161` and `7316-85`.

--- a/tables/zenodo-upload/README.md
+++ b/tables/zenodo-upload/README.md
@@ -99,7 +99,7 @@ Where applicable, all tables are ordered by either `sample_id` or `Kids_First_Bi
 
 #### Figure S2
 
-| Figure Panel | Filename | Brief Description | Notes on Tabular Data |
+| Figure Panel(s) | Filename | Brief Description | Notes on Tabular Data |
 |--------|-------------|--------------------|-------------------------|
 |   S2A-C    |  `figure-S2a-S2b-S2c-data.csv`   | Correlations, distributions, and UpSet plot of mutation VAFs from variant callers for PBTA data, respectively   | This compressed file contains data for all three panels S2A, S2B, and S2C. Caution: Uncompressed, this file is ~3.9 GB.|
 |   S3D-F     |   `figure-S2d-S2e-S2f-data.csv`    |  Correlations, distributions, and UpSet of mutation VAFs from variant callers for TCGA data, respectively       | This compressed file contains data for all three panels S2D, S2E, and S2F. Uncompressed, this file is 13MB.            |
@@ -195,4 +195,4 @@ The alterations for a gene are the union of alterations detected in biospecimens
 * `germline_sex_estimate` is only available for `sample_id`-`composition` pairs that were assayed with WGS.
 * In two instances, multiple RNA biospecimens map to the sample `sample_id`-`composition` pair, and only one RNA biospecimen was assigned the `germline_sex_estimate` derived from the WGS data.
 We only included the non-missing values in these rows.
-The `sample_id`s impacted are `7316-161` and `7316-85`.
+The two `sample_id` instances impacted are `7316-161` and `7316-85`.

--- a/tables/zenodo-upload/README.md
+++ b/tables/zenodo-upload/README.md
@@ -51,120 +51,120 @@ Where applicable, all tables are ordered by either `sample_id` or `Kids_First_Bi
 
 #### Figure 1
 
-| Figure Panel | Filename | Brief Description | Notes on Tabular Data | 
+| Figure Panel | Filename | Brief Description | Notes on Tabular Data |
 |--------|-------------|--------------------|-------------------------|
-|   1B     |  | Barplot showing the number of biospecimens per phase of therapy | |
+|   1B     | `figure-1b-data.csv`  | Barplot showing the number of biospecimens per phase of therapy | |
 
 #### Figure 2
 
-| Figure Panel | Filename | Brief Description | Notes on Tabular Data | 
+| Figure Panel | Filename | Brief Description | Notes on Tabular Data |
 |--------|-------------|--------------------|-------------------------|
-|   2A     |   | Oncoprint summarizing low-grade glioma alterations across samples for top mutated genes           |
-|   2B     |    | Oncoprint summarizing embryonal tumor alterations across samples for top mutated genes         |
-|   2C     |    | Oncoprint summarizing high-grade glioma alterations across samples for top mutated genes         |
-|   2D     |   |  Oncoprint summarizing other CNS tumor alterations across samples for top mutated genes         |
+|   2A     | `figure-2a-data.csv`   | Oncoprint summarizing low-grade glioma alterations across samples for top mutated genes           |
+|   2B     | `figure-2b-data.csv`   | Oncoprint summarizing embryonal tumor alterations across samples for top mutated genes         |
+|   2C     | `figure-2c-data.csv`   | Oncoprint summarizing high-grade glioma alterations across samples for top mutated genes         |
+|   2D     | `figure-2d-data.csv`   |  Oncoprint summarizing other CNS tumor alterations across samples for top mutated genes         |
 #### Figure 3
 
-| Figure Panel | Filename | Brief Description | Notes on Tabular Data | 
+| Figure Panel | Filename | Brief Description | Notes on Tabular Data |
 |--------|-------------|--------------------|-------------------------|
-|   3A     |   | Barplot of occurrence and co-occurrence of nonsynonymous mutations for the 50 most commonly mutated genes across all tumor types         |
-|   3B     |  | Heatmap of co-occurrence and mutual exclusivity of nonsynonymous mutations between genes           |
-|   3C     |  | Scatterplot showing correlation of SV and CNV breaks            |
-|   3D     |  | Barplot showing chromothripsis frequency for all cancer groups with N >= 3 tumors           |
-|   3E     |  | Sina plots of RefSig signature weights across cancer groups         |
+|   3A     | `figure-3a-data.csv`  | Barplot of occurrence and co-occurrence of nonsynonymous mutations for the 50 most commonly mutated genes across all tumor types         |
+|   3B     | `figure-3b-data.csv`  | Heatmap of co-occurrence and mutual exclusivity of nonsynonymous mutations between genes           |
+|   3C     | `figure-3c-data.csv`  | Scatterplot showing correlation of SV and CNV breaks            |
+|   3D     | `figure-3d-data.csv`  | Barplot showing chromothripsis frequency for all cancer groups with N >= 3 tumors           |
+|   3E     | `figure-3e-data.csv`  | Sina plots of RefSig signature weights across cancer groups         |
 #### Figure 4
 
-| Figure Panel | Filename | Brief Description | Notes on Tabular Data | 
+| Figure Panel | Filename | Brief Description | Notes on Tabular Data |
 |--------|-------------|--------------------|-------------------------|
-|   4A     | | ROC curve for TP53 classifier run on stranded RNA-Seq data     |
-|   4B     | | Violin/strip plots of TP53 scores across TP53 alteration status           |
-|   4C     | |  Violin/strip plots of TP53 expression [log(FPKM)] across TP53 alteration status            |
-|   4D     | | Box/strip plots of TP53 scores and telomerase scores across cancer groups          |
-|   4E    |  |  Heatmap of RefSig signatures in patients with a hypermutator phenotype       |
-|   4F     |  | Forest plot from survival analysis exploring TP53 and telomerase score effects          |
-|   4G     |  | Forest plot from survival analysis exploring HGG molecular subtype effects          |
-|   4H     |  | Kaplan-Meier cure of HGG tumors by molecular subtype           |
+|   4A     | `figure-4a-data.csv` | ROC curve for TP53 classifier run on stranded RNA-Seq data     |
+|   4B     | `figure-4b-data.csv` | Violin/strip plots of TP53 scores across TP53 alteration status           |
+|   4C     | `figure-4c-data.csv` |  Violin/strip plots of TP53 expression [log(FPKM)] across TP53 alteration status            |
+|   4D     | `figure-4d-data.csv` | Box/strip plots of TP53 scores and telomerase scores across cancer groups          |
+|   4E     | `figure-4e-data.csv` |  Heatmap of RefSig signatures in patients with a hypermutator phenotype       |
+|   4F     | `figure-4f-data.csv`  | Forest plot from survival analysis exploring TP53 and telomerase score effects          |
+|   4G     | `figure-4g-data.csv`  | Forest plot from survival analysis exploring HGG molecular subtype effects          |
+|   4H     | `figure-4h-data.csv` | Kaplan-Meier cure of HGG tumors by molecular subtype           |
 
 #### Figure 5
 
-| Figure Panel | Filename | Brief Description | Notes on Tabular Data | 
+| Figure Panel | Filename | Brief Description | Notes on Tabular Data |
 |--------|-------------|--------------------|-------------------------|
-|   5A     |  | UMAP of tumors colored by broad histology           |
-|   5B     |  | Heatmap of GSVA scores across cancer groups           |
-|   5C     |  | Box/strip plots of quanTIseq scores across cancer groups           |
-|   5D     |  | Forest plot from survival analysis exploring CD274 expression and immune cell proportion effects           |
+|   5A     | `figure-5a-data.csv`  | UMAP of tumors colored by broad histology           |
+|   5B     | `figure-5b-data.csv`  | Heatmap of GSVA scores across cancer groups           |
+|   5C     | `figure-5c-data.csv`  | Box/strip plots of quanTIseq scores across cancer groups           |
+|   5D     | `figure-5d-data.csv`  | Forest plot from survival analysis exploring CD274 expression and immune cell proportion effects           |
 
 
 ### Supplemental Figure Data
 
 #### Figure S2
 
-| Figure Panel | Filename | Brief Description | Notes on Tabular Data | 
+| Figure Panel | Filename | Brief Description | Notes on Tabular Data |
 |--------|-------------|--------------------|-------------------------|
-|   S2A     |             |             |
-|   S2B     |             |             |
-|   S2C     |             |             |
-|   S3D     |             |             |
-|   S2E     |             |             |
-|   S2F     |             |             |
-|   S2G     |             |             |
-|   S2H     |             |             |
-|   S2I     |             |             |
+|   S2A     |  `figure-S2a-S2b-S2c-data.csv`   |             |
+|   S2B     |  `figure-S2a-S2b-S2c-data.csv`           |             |
+|   S2C     |  `figure-S2a-S2b-S2c-data.csv`           |             |
+|   S3D     |   `figure-S2d-S2e-S2f-data.csv`          |             |
+|   S2E     |   `figure-S2d-S2e-S2f-data.csv`          |             |
+|   S2F     |   `figure-S2d-S2e-S2f-data.csv`            |             |
+|   S2G     |   `figure-S2g-data.csv`          |             |
+|   S2H     |   `figure-S2h-data.csv`         |             |
+|   S2I     |   `figure-S2i-data.csv`         |             |
 
 #### Figure S3
 
-| Figure Panel | Filename | Brief Description | Notes on Tabular Data | 
+| Figure Panel | Filename | Brief Description | Notes on Tabular Data |
 |--------|-------------|--------------------|-------------------------|
-|   S3A     |             |             |
-|   S3B     |             |             |
-|   S3C     |             |             |
-|   S3D     |             |             |
-|   S3E     |             |             |
+|   S3A     |    `figure-S3a-data.csv`         |             |
+|   S3B     |    `figure-S3b-data.csv`          |             |
+|   S3C     |    `figure-S3c-data.csv.gz`          |             |
+|   S3D     |    `figure-S3d-data.csv`          |             |
+|   S3E     |    `figure-S3e-data.csv`          |             |
 
 
 #### Figure S4
 
-| Figure Panel | Filename | Brief Description | Notes on Tabular Data | 
+| Figure Panel | Filename | Brief Description | Notes on Tabular Data |
 |--------|-------------|--------------------|-------------------------|
-|   S4A     |             |             |
-|   S4B     |             |             |
+|   S4A     |   `figure-S4a-data.csv`           |             |
+|   S4B     |   `figure-S4b-data.csv`           |             |
 
 
 #### Figure S5
 
-| Figure Panel | Filename | Brief Description | Notes on Tabular Data | 
+| Figure Panel | Filename | Brief Description | Notes on Tabular Data |
 |--------|-------------|--------------------|-------------------------|
-|   S5A     |             |             |
-|   S5B     |             |             |
-|   S5C     |             |             |
+|   S5A     |  `figure-S5a-data.csv`            |             |
+|   S5B     |  `figure-S5b-data.csv`            |             |
+|   S5C     |  `figure-S5c-data.csv`            |             |
 
 
 
 #### Figure S6
 
-| Figure Panel | Filename | Brief Description | Notes on Tabular Data | 
+| Figure Panel | Filename | Brief Description | Notes on Tabular Data |
 |--------|-------------|--------------------|-------------------------|
-|   S6A     |             |             |
-|   S6B     |             |             |
-|   S6C     |             |             |
-|   S6D     |             |             |
-|   S6E     |             |             |
-|   S6F     |             |             |
+|   S6A     |   `figure-S6a-data.csv`          |             |
+|   S6B     |   `figure-S6b-data.csv`          |             |
+|   S6C     |   `figure-S6c-data.csv`          |             |
+|   S6D     |   `figure-S6d-data.csv`          |             |
+|   S6E     |   `figure-S6e-data.csv`          |             |
+|   S6F     |   `figure-S6f-data.csv`          |             |
 
 
 #### Figure S7
 
-| Figure Panel | Filename | Brief Description | Notes on Tabular Data | 
+| Figure Panel | Filename | Brief Description | Notes on Tabular Data |
 |--------|-------------|--------------------|-------------------------|
-|   S7A     |             |             |
-|   S7B     |             |             |
-|   S7C     |             |             |
-|   S7D     |             |             |
-|   S7E     |             |             |
-|   S7F     |             |             |
-|   S7G     |             |             |
-|   S7H     |             |             |
-|   S7I     |             |             |
+|   S7A     |   `figure-7a-data.csv`          |             |
+|   S7B     |   `figure-7b-data.csv`            |             |
+|   S7C     |   `figure-7c-data.csv`           |             |
+|   S7D     |   `figure-7d-data.csv`           |             |
+|   S7E     |   `figure-7e-data.csv`           |             |
+|   S7F     |   `figure-7f-data.csv`           |             |
+|   S7G     |   `figure-7g-data.csv`           |             |
+|   S7H     |   `figure-7h-data.csv`           |             |
+|   S7I     |   `figure-7i-data.csv`           |             |
 
 
 ## Molecular Alterations
@@ -173,7 +173,7 @@ Please see the `tables/tabulate-molecular-alterations.R` script in the `OpenPBTA
 
 ### File Description
 
-`openpbta-molecular-alterations.csv` contains information about the alterations (SNV, CNV, and fusions) a sample has in any gene included in the oncoprints in the manuscript (i.e., Figure 2 and Figure S3B). 
+`openpbta-molecular-alterations.csv` contains information about the alterations (SNV, CNV, and fusions) a sample has in any gene included in the oncoprints in the manuscript (i.e., Figure 2 and Figure S3B).
 
 In the case of multiple alterations affecting the same gene, individual alterations are separated by semi-colons.
 We use the value `None` when no gene alterations are detected in the consensus data.
@@ -187,13 +187,13 @@ We include `Kids_First_Biospecimen_DNA` and `Kids_First_Biospecimen_RNA` columns
 * For SNV data, we prioritize values from the consensus MAF file (`pbta-snv-consensus-mutation.maf.tsv.gz`) for inclusion in the following order: `HGVSp_Short`, `HGVSc`, and `Variant_Type`.
 When no change in the protein is noted in the `HGVSp_Short` value, we use the nucleotide change.
 * CNV alterations use the following notation from the `consensus_seg_annotated_*` files included in the data download: `<cytoband>-<status>-<copy_number>`.
-* We report the `FusionName` field from `pbta-fusion-putative-oncogenic.tsv` for fusions. 
+* We report the `FusionName` field from `pbta-fusion-putative-oncogenic.tsv` for fusions.
 When reciprocal fusions are detected, we only report one – whichever comes first when partner genes are sorted alphabetically.
 
 ### Caveats
 
 * Some `sample_id`-`composition` pairs map to multiple biospecimens of the same type (i.e., DNA and RNA).
-When this occurs, the individual biospecimen identifiers are separated with semi-colons in the relevant column, and `multiple_assays_within_type` is marked as `TRUE`. 
+When this occurs, the individual biospecimen identifiers are separated with semi-colons in the relevant column, and `multiple_assays_within_type` is marked as `TRUE`.
 The alterations for a gene are the union of alterations detected in biospecimens (i.e., they are detected in at least one biospecimen).
 * If multiple `cancer_type` or `broad_histology` values are associated with the same `sample_id`-`composition` pair, these values are semi-colon separated.
 * `germline_sex_estimate` is only available for `sample_id`-`composition` pairs that were assayed with WGS.

--- a/tables/zenodo-upload/README.md
+++ b/tables/zenodo-upload/README.md
@@ -195,4 +195,4 @@ The alterations for a gene are the union of alterations detected in biospecimens
 * `germline_sex_estimate` is only available for `sample_id`-`composition` pairs that were assayed with WGS.
 * In two instances, multiple RNA biospecimens map to the sample `sample_id`-`composition` pair, and only one RNA biospecimen was assigned the `germline_sex_estimate` derived from the WGS data.
 We only included the non-missing values in these rows.
-The two `sample_id` instances impacted are `7316-161` and `7316-85`.
+The `sample_id` impacted are `7316-161` and `7316-85`.


### PR DESCRIPTION
Closes #1716 
This PR finishes the README for Zenodo files. I filled in remaining table items, and did one smol tweak on the last line of the file (pluralify `sample_id` -> `sample_id`s - does this look weird though in the rendered view?). 

A key part to review here is the "Notes on Tabular Data" - should anything here be rephrased or reorganized, and/or is there anything we think I've missed? I wondered, for example, if we might want to link the `tumor-purity-exploration` module in the high tumor purity notes - I'm really on the fence for that, so can figure out in review!

I also expanded the `.gitignore` to ignore the uncompressed versions of compressed files, which felt like a safe thing to do..!