### PR TITLE
Fix 1B Zenodo csv export

### DIFF
--- a/figures/scripts/fig1-sample-distribution.R
+++ b/figures/scripts/fig1-sample-distribution.R
@@ -219,6 +219,8 @@ ggsave(filename = file.path(main_output_dir,
 
 # Export figure data for zenodo upload
 data_descriptor_plot %>%
+  # remove columns with \n and other unneeded columns
+  dplyr::select(-bh_strip, -abbr, -broad_histology, -broad_histology_hex, -broad_histology_order) %>%
   dplyr::arrange(sample_id) %>%
   readr::write_csv(fig1b_csv)
 

--- a/tables/zenodo-upload/figure-1b-data.csv
+++ b/tables/zenodo-upload/figure-1b-data.csv
@@ -1,1163 +1,1048 @@
-sample_id,broad_histology,cancer_group,tumor_descriptor,broad_histology_hex,broad_histology_display,broad_histology_order,cancer_group_display,cancer_group_abbreviation,bh_strip,abbr
-7316-10,Tumor of cranial and paraspinal nerves,Neurofibroma Plexiform,Initial CNS Tumor,#ffaa00,Tumor of cranial and paraspinal nerves,5,Neurofibroma Plexiform,PNF,"Tumor of cranial and
-paraspinal nerves",PNF
-7316-100,Tumors of sellar region,Craniopharyngioma,Initial CNS Tumor,#b2502d,Tumor of sellar region,7,Craniopharyngioma,CRANIO,Tumor of sellar region,CRANIO
-7316-101,Low-grade astrocytic tumor,Ganglioglioma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Ganglioglioma,GNG,Low-grade glioma,GNG
-7316-1038,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-104,Germ cell tumor,Teratoma,Recurrence,#0074d9,Germ cell tumor,10,Teratoma,Teratoma,Germ cell tumor,Teratoma
-7316-1052,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-1055,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Second Malignancy,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-1057,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Progressive,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-1059,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-1060,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-1062,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Progressive,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-1064,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-1068,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Progressive,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-1069,Benign tumor,Adenoma,Initial CNS Tumor,#590024,Benign tumor,11,Other,Other,Benign tumor,Other
-7316-1070,Neuronal and mixed neuronal-glial tumor,Dysembryoplastic neuroepithelial tumor,Progressive,#685815,Neuronal and mixed neuronal-glial tumor,6,Dysembryoplastic neuroepithelial tumor,DNET,"Neuronal and mixed
-neuronal-glial tumor",DNET
-7316-1071,Low-grade astrocytic tumor,Ganglioglioma,Recurrence,#8f8fbf,Low-grade glioma,1,Ganglioglioma,GNG,Low-grade glioma,GNG
-7316-1073,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,Initial CNS Tumor,#220040,Embryonal tumor,3,Atypical Teratoid Rhabdoid Tumor,ATRT,Embryonal tumor,ATRT
-7316-1075,Tumors of sellar region,Craniopharyngioma,Initial CNS Tumor,#b2502d,Tumor of sellar region,7,Craniopharyngioma,CRANIO,Tumor of sellar region,CRANIO
-7316-1077,Low-grade astrocytic tumor,Ganglioglioma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Ganglioglioma,GNG,Low-grade glioma,GNG
-7316-1078,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-1079,Mesenchymal non-meningothelial tumor,Ewing sarcoma,Initial CNS Tumor,#7fbf00,Mesenchymal non-meningothelial tumor,9,Ewing sarcoma,EWS,"Mesenchymal non-
-meningothelial tumor",EWS
-7316-1080,Benign tumor,Adenoma,Initial CNS Tumor,#590024,Benign tumor,11,Other,Other,Benign tumor,Other
-7316-1081,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-1082,Tumors of sellar region,Craniopharyngioma,Initial CNS Tumor,#b2502d,Tumor of sellar region,7,Craniopharyngioma,CRANIO,Tumor of sellar region,CRANIO
-7316-1083,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-1084,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-1085,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-1086,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-1087,Low-grade astrocytic tumor,Subependymal Giant Cell Astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Subependymal Giant Cell Astrocytoma,SEGA,Low-grade glioma,SEGA
-7316-1088,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-1089,Neuronal and mixed neuronal-glial tumor,Dysembryoplastic neuroepithelial tumor,Initial CNS Tumor,#685815,Neuronal and mixed neuronal-glial tumor,6,Dysembryoplastic neuroepithelial tumor,DNET,"Neuronal and mixed
-neuronal-glial tumor",DNET
-7316-109,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-1090,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-1093,Neuronal and mixed neuronal-glial tumor,Dysembryoplastic neuroepithelial tumor,Initial CNS Tumor,#685815,Neuronal and mixed neuronal-glial tumor,6,Dysembryoplastic neuroepithelial tumor,DNET,"Neuronal and mixed
-neuronal-glial tumor",DNET
-7316-1094,Tumor of cranial and paraspinal nerves,Schwannoma,Initial CNS Tumor,#ffaa00,Tumor of cranial and paraspinal nerves,5,Schwannoma,Schwannoma,"Tumor of cranial and
-paraspinal nerves",Schwannoma
-7316-1095,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-1096,Benign tumor,Adenoma,Initial CNS Tumor,#590024,Benign tumor,11,Other,Other,Benign tumor,Other
-7316-1099,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-1100,Embryonal tumor,CNS Embryonal tumor,Recurrence,#220040,Embryonal tumor,3,Other embryonal tumor,Other ET,Embryonal tumor,Other ET
-7316-1101,Chordoma,Chordoma,Initial CNS Tumor,#808080,Other,12,Other,Other,Other,Other
-7316-1102,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-1103,Benign tumor,Choroid plexus papilloma,Initial CNS Tumor,#590024,Benign tumor,11,Choroid plexus papilloma,CPP,Benign tumor,CPP
-7316-1104,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-1105,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Recurrence,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-1106,Low-grade astrocytic tumor,Pleomorphic xanthoastrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pleomorphic xanthoastrocytoma,PXA,Low-grade glioma,PXA
-7316-1107,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-1108,Low-grade astrocytic tumor,Ganglioglioma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Ganglioglioma,GNG,Low-grade glioma,GNG
-7316-1109,Neuronal and mixed neuronal-glial tumor,Rosette-forming glioneuronal tumor,Recurrence,#685815,Neuronal and mixed neuronal-glial tumor,6,Other,Other,"Neuronal and mixed
-neuronal-glial tumor",Other
-7316-111,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-1113,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-1114,Low-grade astrocytic tumor,Ganglioglioma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Ganglioglioma,GNG,Low-grade glioma,GNG
-7316-1115,Germ cell tumor,Teratoma,Initial CNS Tumor,#0074d9,Germ cell tumor,10,Teratoma,Teratoma,Germ cell tumor,Teratoma
-7316-1116,Tumors of sellar region,Craniopharyngioma,Recurrence,#b2502d,Tumor of sellar region,7,Craniopharyngioma,CRANIO,Tumor of sellar region,CRANIO
-7316-1117,Neuronal and mixed neuronal-glial tumor,Dysembryoplastic neuroepithelial tumor,Recurrence,#685815,Neuronal and mixed neuronal-glial tumor,6,Dysembryoplastic neuroepithelial tumor,DNET,"Neuronal and mixed
-neuronal-glial tumor",DNET
-7316-1118,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-1134,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-1137,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,Initial CNS Tumor,#220040,Embryonal tumor,3,Atypical Teratoid Rhabdoid Tumor,ATRT,Embryonal tumor,ATRT
-7316-114,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Second Malignancy,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-116,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-117,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-1187,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-119,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-120,Low-grade astrocytic tumor,Ganglioglioma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Ganglioglioma,GNG,Low-grade glioma,GNG
-7316-121,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-1214,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-122,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,Initial CNS Tumor,#220040,Embryonal tumor,3,Atypical Teratoid Rhabdoid Tumor,ATRT,Embryonal tumor,ATRT
-7316-1226,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-124,Tumors of sellar region,Craniopharyngioma,Initial CNS Tumor,#b2502d,Tumor of sellar region,7,Craniopharyngioma,CRANIO,Tumor of sellar region,CRANIO
-7316-125,Embryonal tumor,Neuroblastoma,Progressive,#220040,Embryonal tumor,3,Other embryonal tumor,Other ET,Embryonal tumor,Other ET
-7316-1252,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-126,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Progressive,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-127,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-1279,Ependymal tumor,Ependymoma,Recurrence,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-128,Mesenchymal non-meningothelial tumor,Ewing sarcoma,Progressive,#7fbf00,Mesenchymal non-meningothelial tumor,9,Ewing sarcoma,EWS,"Mesenchymal non-
-meningothelial tumor",EWS
-7316-129,Meningioma,Meningioma,Initial CNS Tumor,#2db398,Meningioma,8,Meningioma,Meningioma,Meningioma,Meningioma
-7316-13,Tumor of cranial and paraspinal nerves,Neurofibroma Plexiform,Initial CNS Tumor,#ffaa00,Tumor of cranial and paraspinal nerves,5,Neurofibroma Plexiform,PNF,"Tumor of cranial and
-paraspinal nerves",PNF
-7316-1312,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-133,Diffuse astrocytic and oligodendroglial tumor,Oligodendroglioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-134,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-135,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-136,Low-grade astrocytic tumor,Pleomorphic xanthoastrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pleomorphic xanthoastrocytoma,PXA,Low-grade glioma,PXA
-7316-14,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-1455,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-1459,Tumor of cranial and paraspinal nerves,Malignant peripheral nerve sheath tumor,Initial CNS Tumor,#ffaa00,Tumor of cranial and paraspinal nerves,5,Other,Other,"Tumor of cranial and
-paraspinal nerves",Other
-7316-146,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-1460,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-1461,Meningioma,Meningioma,Initial CNS Tumor,#2db398,Meningioma,8,Meningioma,Meningioma,Meningioma,Meningioma
-7316-1463,Tumor of cranial and paraspinal nerves,Schwannoma,Initial CNS Tumor,#ffaa00,Tumor of cranial and paraspinal nerves,5,Schwannoma,Schwannoma,"Tumor of cranial and
-paraspinal nerves",Schwannoma
-7316-1464,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-147,Tumor of cranial and paraspinal nerves,Schwannoma,Initial CNS Tumor,#ffaa00,Tumor of cranial and paraspinal nerves,5,Schwannoma,Schwannoma,"Tumor of cranial and
-paraspinal nerves",Schwannoma
-7316-1473,Embryonal tumor,CNS neuroblastoma,Recurrence,#220040,Embryonal tumor,3,Other embryonal tumor,Other ET,Embryonal tumor,Other ET
-7316-1476,Meningioma,Meningioma,Progressive,#2db398,Meningioma,8,Meningioma,Meningioma,Meningioma,Meningioma
-7316-148,Low-grade astrocytic tumor,Pilocytic astrocytoma,Recurrence,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-1480,Ependymal tumor,Ependymoma,Progressive,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-152,Low-grade astrocytic tumor,Oligodendroglioma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-153,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-154,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Progressive,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-155,Embryonal tumor,CNS Embryonal tumor,Initial CNS Tumor,#220040,Embryonal tumor,3,Other embryonal tumor,Other ET,Embryonal tumor,Other ET
-7316-156,Low-grade astrocytic tumor,Ganglioglioma,Progressive,#8f8fbf,Low-grade glioma,1,Ganglioglioma,GNG,Low-grade glioma,GNG
-7316-157,Neuronal and mixed neuronal-glial tumor,Dysembryoplastic neuroepithelial tumor,Initial CNS Tumor,#685815,Neuronal and mixed neuronal-glial tumor,6,Dysembryoplastic neuroepithelial tumor,DNET,"Neuronal and mixed
-neuronal-glial tumor",DNET
-7316-158,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-159,Tumor of cranial and paraspinal nerves,Schwannoma,Initial CNS Tumor,#ffaa00,Tumor of cranial and paraspinal nerves,5,Schwannoma,Schwannoma,"Tumor of cranial and
-paraspinal nerves",Schwannoma
-7316-16,Metastatic tumors,Metastatic secondary tumors,Initial CNS Tumor,#808080,Other,12,Other,Other,Other,Other
-7316-160,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-161,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-162,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-1635,Low-grade astrocytic tumor,Pleomorphic xanthoastrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pleomorphic xanthoastrocytoma,PXA,Low-grade glioma,PXA
-7316-1636,Low-grade astrocytic tumor,Ganglioglioma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Ganglioglioma,GNG,Low-grade glioma,GNG
-7316-1637,Neuronal and mixed neuronal-glial tumor,Glial-neuronal tumor NOS,Initial CNS Tumor,#685815,Neuronal and mixed neuronal-glial tumor,6,Other,Other,"Neuronal and mixed
-neuronal-glial tumor",Other
-7316-164,Tumors of sellar region,Craniopharyngioma,Progressive,#b2502d,Tumor of sellar region,7,Craniopharyngioma,CRANIO,Tumor of sellar region,CRANIO
-7316-1641,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-1642,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-1643,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-1646,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-1648,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-1649,Histiocytic tumor,Rosai-Dorfman disease,Initial CNS Tumor,#808080,Other,12,Other,Other,Other,Other
-7316-1650,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-1651,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-1652,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-1653,Tumors of sellar region,Craniopharyngioma,Initial CNS Tumor,#b2502d,Tumor of sellar region,7,Craniopharyngioma,CRANIO,Tumor of sellar region,CRANIO
-7316-1654,Benign tumor,Atypical choroid plexus papilloma,Initial CNS Tumor,#590024,Benign tumor,11,Other,Other,Benign tumor,Other
-7316-1655,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-1656,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Recurrence,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-1658,Low-grade astrocytic tumor,Subependymal Giant Cell Astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Subependymal Giant Cell Astrocytoma,SEGA,Low-grade glioma,SEGA
-7316-1659,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-166,Tumors of sellar region,Craniopharyngioma,Initial CNS Tumor,#b2502d,Tumor of sellar region,7,Craniopharyngioma,CRANIO,Tumor of sellar region,CRANIO
-7316-1660,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-1661,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Recurrence,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-1664,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-1666,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-1668,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-1669,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-167,Low-grade astrocytic tumor,Diffuse fibrillary astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-1670,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-1671,Tumors of sellar region,Craniopharyngioma,Initial CNS Tumor,#b2502d,Tumor of sellar region,7,Craniopharyngioma,CRANIO,Tumor of sellar region,CRANIO
-7316-1676,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-1677,Tumor of cranial and paraspinal nerves,Neurofibroma Plexiform,Initial CNS Tumor,#ffaa00,Tumor of cranial and paraspinal nerves,5,Neurofibroma Plexiform,PNF,"Tumor of cranial and
-paraspinal nerves",PNF
-7316-1678,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-1679,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-168,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-1680,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-1681,Low-grade astrocytic tumor,Subependymal Giant Cell Astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Subependymal Giant Cell Astrocytoma,SEGA,Low-grade glioma,SEGA
-7316-1683,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-1693,Benign tumor,Choroid plexus papilloma,Initial CNS Tumor,#590024,Benign tumor,11,Choroid plexus papilloma,CPP,Benign tumor,CPP
-7316-1694,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Progressive,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-1695,Diffuse astrocytic and oligodendroglial tumor,Diffuse intrinsic pontine glioma,Progressive,#ff80e5,High-grade glioma,2,Diffuse intrinsic pontine glioma,DIPG,High-grade glioma,DIPG
-7316-170,Tumor of cranial and paraspinal nerves,Neurofibroma Plexiform,Recurrence,#ffaa00,Tumor of cranial and paraspinal nerves,5,Neurofibroma Plexiform,PNF,"Tumor of cranial and
-paraspinal nerves",PNF
-7316-1700,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-1702,Meningioma,Meningioma,Initial CNS Tumor,#2db398,Meningioma,8,Meningioma,Meningioma,Meningioma,Meningioma
-7316-1703,Meningioma,Meningioma,Second Malignancy,#2db398,Meningioma,8,Meningioma,Meningioma,Meningioma,Meningioma
-7316-1704,Mesenchymal non-meningothelial tumor,Hemangioblastoma,Initial CNS Tumor,#7fbf00,Mesenchymal non-meningothelial tumor,9,Other,Other,"Mesenchymal non-
-meningothelial tumor",Other
-7316-1705,Meningioma,Meningioma,Progressive,#2db398,Meningioma,8,Meningioma,Meningioma,Meningioma,Meningioma
-7316-1706,Ependymal tumor,Ependymoma,Progressive,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-1708,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Progressive,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-1710,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-1711,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-1714,Embryonal tumor,Medulloblastoma,Recurrence,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-1715,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-1723,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Progressive,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-173,Low-grade astrocytic tumor,Pilocytic astrocytoma,Second Malignancy,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-174,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-1744,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-1745,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Progressive,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-1746,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-1747,Mesenchymal non-meningothelial tumor,Sarcoma,Initial CNS Tumor,#7fbf00,Mesenchymal non-meningothelial tumor,9,Other,Other,"Mesenchymal non-
-meningothelial tumor",Other
-7316-1748,Tumors of sellar region,Craniopharyngioma,Initial CNS Tumor,#b2502d,Tumor of sellar region,7,Craniopharyngioma,CRANIO,Tumor of sellar region,CRANIO
-7316-1749,Neuronal and mixed neuronal-glial tumor,Dysembryoplastic neuroepithelial tumor,Recurrence,#685815,Neuronal and mixed neuronal-glial tumor,6,Dysembryoplastic neuroepithelial tumor,DNET,"Neuronal and mixed
-neuronal-glial tumor",DNET
-7316-175,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-1750,Neuronal and mixed neuronal-glial tumor,Dysembryoplastic neuroepithelial tumor,Initial CNS Tumor,#685815,Neuronal and mixed neuronal-glial tumor,6,Dysembryoplastic neuroepithelial tumor,DNET,"Neuronal and mixed
-neuronal-glial tumor",DNET
-7316-1751,Tumors of sellar region,Craniopharyngioma,Progressive,#b2502d,Tumor of sellar region,7,Craniopharyngioma,CRANIO,Tumor of sellar region,CRANIO
-7316-1757,Tumor of cranial and paraspinal nerves,Neurofibroma Plexiform,Recurrence,#ffaa00,Tumor of cranial and paraspinal nerves,5,Neurofibroma Plexiform,PNF,"Tumor of cranial and
-paraspinal nerves",PNF
-7316-176,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-1760,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-1763,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-1765,Tumor of pineal region,Pineoblastoma,Initial CNS Tumor,#808080,Other,12,Other,Other,Other,Other
-7316-1766,Mesenchymal non-meningothelial tumor,Hemangioblastoma,Progressive,#7fbf00,Mesenchymal non-meningothelial tumor,9,Other,Other,"Mesenchymal non-
-meningothelial tumor",Other
-7316-1767,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-1769,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Progressive,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-177,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Recurrence,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-1771,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,Initial CNS Tumor,#220040,Embryonal tumor,3,Atypical Teratoid Rhabdoid Tumor,ATRT,Embryonal tumor,ATRT
-7316-1772,Embryonal tumor,Medulloblastoma,Progressive,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-1773,Tumors of sellar region,Craniopharyngioma,Initial CNS Tumor,#b2502d,Tumor of sellar region,7,Craniopharyngioma,CRANIO,Tumor of sellar region,CRANIO
-7316-1774,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Progressive,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-1775,Tumors of sellar region,Craniopharyngioma,Initial CNS Tumor,#b2502d,Tumor of sellar region,7,Craniopharyngioma,CRANIO,Tumor of sellar region,CRANIO
-7316-1776,Neuronal and mixed neuronal-glial tumor,Dysembryoplastic neuroepithelial tumor,Initial CNS Tumor,#685815,Neuronal and mixed neuronal-glial tumor,6,Dysembryoplastic neuroepithelial tumor,DNET,"Neuronal and mixed
-neuronal-glial tumor",DNET
-7316-1778,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,Initial CNS Tumor,#220040,Embryonal tumor,3,Atypical Teratoid Rhabdoid Tumor,ATRT,Embryonal tumor,ATRT
-7316-1779,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-178,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-1781,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,Initial CNS Tumor,#220040,Embryonal tumor,3,Atypical Teratoid Rhabdoid Tumor,ATRT,Embryonal tumor,ATRT
-7316-1782,Neuronal and mixed neuronal-glial tumor,Neurocytoma,Initial CNS Tumor,#685815,Neuronal and mixed neuronal-glial tumor,6,Other,Other,"Neuronal and mixed
-neuronal-glial tumor",Other
-7316-1783,Low-grade astrocytic tumor,Ganglioglioma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Ganglioglioma,GNG,Low-grade glioma,GNG
-7316-1784,Ependymal tumor,Ependymoma,Recurrence,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-1785,Germ cell tumor,Germinoma,Initial CNS Tumor,#0074d9,Germ cell tumor,10,Other,Other,Germ cell tumor,Other
-7316-1786,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-1789,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Recurrence,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-179,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-1790,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,Progressive,#220040,Embryonal tumor,3,Atypical Teratoid Rhabdoid Tumor,ATRT,Embryonal tumor,ATRT
-7316-1792,Meningioma,Meningioma,Progressive,#2db398,Meningioma,8,Meningioma,Meningioma,Meningioma,Meningioma
-7316-1793,Low-grade astrocytic tumor,Ganglioglioma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Ganglioglioma,GNG,Low-grade glioma,GNG
-7316-1794,Low-grade astrocytic tumor,Pilocytic astrocytoma,Progressive,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-1795,Tumors of sellar region,Craniopharyngioma,Initial CNS Tumor,#b2502d,Tumor of sellar region,7,Craniopharyngioma,CRANIO,Tumor of sellar region,CRANIO
-7316-1797,Neuronal and mixed neuronal-glial tumor,Dysembryoplastic neuroepithelial tumor,Recurrence,#685815,Neuronal and mixed neuronal-glial tumor,6,Dysembryoplastic neuroepithelial tumor,DNET,"Neuronal and mixed
-neuronal-glial tumor",DNET
-7316-1799,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-1801,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-1802,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-1803,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-1805,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-1806,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-1808,Meningioma,Meningioma,Initial CNS Tumor,#2db398,Meningioma,8,Meningioma,Meningioma,Meningioma,Meningioma
-7316-182,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-183,Low-grade astrocytic tumor,Gliomatosis cerebri,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-184,Low-grade astrocytic tumor,Diffuse fibrillary astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-1844,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-1845,Low-grade astrocytic tumor,Diffuse fibrillary astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-185,Mesenchymal non-meningothelial tumor,Ewing sarcoma,Initial CNS Tumor,#7fbf00,Mesenchymal non-meningothelial tumor,9,Ewing sarcoma,EWS,"Mesenchymal non-
-meningothelial tumor",EWS
-7316-1851,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-1854,Low-grade astrocytic tumor,Ganglioglioma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Ganglioglioma,GNG,Low-grade glioma,GNG
-7316-1855,Lymphoma,CNS Burkitt's lymphoma,Initial CNS Tumor,#808080,Other,12,Other,Other,Other,Other
-7316-1856,Mesenchymal non-meningothelial tumor,Ewing sarcoma,Initial CNS Tumor,#7fbf00,Mesenchymal non-meningothelial tumor,9,Ewing sarcoma,EWS,"Mesenchymal non-
-meningothelial tumor",EWS
-7316-186,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-1866,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-188,Tumors of sellar region,Craniopharyngioma,Initial CNS Tumor,#b2502d,Tumor of sellar region,7,Craniopharyngioma,CRANIO,Tumor of sellar region,CRANIO
-7316-1884,Embryonal tumor,Medulloblastoma,Progressive,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-1886,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-1889,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Progressive,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-189,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-1890,Neuronal and mixed neuronal-glial tumor,Desmoplastic infantile astrocytoma and ganglioglioma,Progressive,#685815,Neuronal and mixed neuronal-glial tumor,6,Other,Other,"Neuronal and mixed
-neuronal-glial tumor",Other
-7316-1893,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Recurrence,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-19,Metastatic tumors,Metastatic secondary tumors,Progressive,#808080,Other,12,Other,Other,Other,Other
-7316-1926,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-1927,Embryonal tumor,Neuroblastoma,Progressive,#220040,Embryonal tumor,3,Other embryonal tumor,Other ET,Embryonal tumor,Other ET
-7316-1928,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-193,Low-grade astrocytic tumor,Diffuse fibrillary astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-1936,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-1937,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-194,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-1940,Low-grade astrocytic tumor,Ganglioglioma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Ganglioglioma,GNG,Low-grade glioma,GNG
-7316-1941,Neuronal and mixed neuronal-glial tumor,Dysembryoplastic neuroepithelial tumor,Progressive,#685815,Neuronal and mixed neuronal-glial tumor,6,Dysembryoplastic neuroepithelial tumor,DNET,"Neuronal and mixed
-neuronal-glial tumor",DNET
-7316-1942,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-1943,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-1944,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-1945,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-1946,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-1948,Neuronal and mixed neuronal-glial tumor,Dysembryoplastic neuroepithelial tumor,Initial CNS Tumor,#685815,Neuronal and mixed neuronal-glial tumor,6,Dysembryoplastic neuroepithelial tumor,DNET,"Neuronal and mixed
-neuronal-glial tumor",DNET
-7316-1949,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-195,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-1950,Tumors of sellar region,Craniopharyngioma,Initial CNS Tumor,#b2502d,Tumor of sellar region,7,Craniopharyngioma,CRANIO,Tumor of sellar region,CRANIO
-7316-1952,Low-grade astrocytic tumor,Ganglioglioma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Ganglioglioma,GNG,Low-grade glioma,GNG
-7316-1953,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-1954,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-1955,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-1956,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-1957,Low-grade astrocytic tumor,Subependymal Giant Cell Astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Subependymal Giant Cell Astrocytoma,SEGA,Low-grade glioma,SEGA
-7316-1958,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-1959,Mesenchymal non-meningothelial tumor,Rhabdomyosarcoma,Initial CNS Tumor,#7fbf00,Mesenchymal non-meningothelial tumor,9,Other,Other,"Mesenchymal non-
-meningothelial tumor",Other
-7316-196,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-1960,Benign tumor,Adenoma,Initial CNS Tumor,#590024,Benign tumor,11,Other,Other,Benign tumor,Other
-7316-1961,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-1963,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-1965,Low-grade astrocytic tumor,Ganglioglioma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Ganglioglioma,GNG,Low-grade glioma,GNG
-7316-1968,Mesenchymal non-meningothelial tumor,Rhabdomyosarcoma,Initial CNS Tumor,#7fbf00,Mesenchymal non-meningothelial tumor,9,Other,Other,"Mesenchymal non-
-meningothelial tumor",Other
-7316-1969,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-197,Benign tumor,Choroid plexus papilloma,Initial CNS Tumor,#590024,Benign tumor,11,Choroid plexus papilloma,CPP,Benign tumor,CPP
-7316-1970,Neuronal and mixed neuronal-glial tumor,Dysembryoplastic neuroepithelial tumor,Initial CNS Tumor,#685815,Neuronal and mixed neuronal-glial tumor,6,Dysembryoplastic neuroepithelial tumor,DNET,"Neuronal and mixed
-neuronal-glial tumor",DNET
-7316-1972,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-1975,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-1977,Low-grade astrocytic tumor,Subependymal Giant Cell Astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Subependymal Giant Cell Astrocytoma,SEGA,Low-grade glioma,SEGA
-7316-1978,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-198,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-1981,Embryonal tumor,CNS Embryonal tumor,Initial CNS Tumor,#220040,Embryonal tumor,3,Other embryonal tumor,Other ET,Embryonal tumor,Other ET
-7316-1983,Tumor of cranial and paraspinal nerves,Schwannoma,Initial CNS Tumor,#ffaa00,Tumor of cranial and paraspinal nerves,5,Schwannoma,Schwannoma,"Tumor of cranial and
-paraspinal nerves",Schwannoma
-7316-1985,Low-grade astrocytic tumor,Ganglioglioma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Ganglioglioma,GNG,Low-grade glioma,GNG
-7316-1986,Meningioma,Meningioma,Initial CNS Tumor,#2db398,Meningioma,8,Meningioma,Meningioma,Meningioma,Meningioma
-7316-1987,Tumor of cranial and paraspinal nerves,Schwannoma,Initial CNS Tumor,#ffaa00,Tumor of cranial and paraspinal nerves,5,Schwannoma,Schwannoma,"Tumor of cranial and
-paraspinal nerves",Schwannoma
-7316-20,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-2005,Low-grade astrocytic tumor,Ganglioglioma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Ganglioglioma,GNG,Low-grade glioma,GNG
-7316-2006,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-2009,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-202,Other tumor,Ganglioneuroma,Initial CNS Tumor,#808080,Other,12,Other,Other,Other,Other
-7316-204,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-205,Tumors of sellar region,Craniopharyngioma,Initial CNS Tumor,#b2502d,Tumor of sellar region,7,Craniopharyngioma,CRANIO,Tumor of sellar region,CRANIO
-7316-206,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-2069,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Recurrence,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-207,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-2071,Meningioma,Meningioma,Initial CNS Tumor,#2db398,Meningioma,8,Meningioma,Meningioma,Meningioma,Meningioma
-7316-2075,Low-grade astrocytic tumor,Pleomorphic xanthoastrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pleomorphic xanthoastrocytoma,PXA,Low-grade glioma,PXA
-7316-2079,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-2084,Tumor of cranial and paraspinal nerves,Schwannoma,Initial CNS Tumor,#ffaa00,Tumor of cranial and paraspinal nerves,5,Schwannoma,Schwannoma,"Tumor of cranial and
-paraspinal nerves",Schwannoma
-7316-2085,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Progressive,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-209,Tumor of cranial and paraspinal nerves,Neurofibroma Plexiform,Progressive,#ffaa00,Tumor of cranial and paraspinal nerves,5,Neurofibroma Plexiform,PNF,"Tumor of cranial and
-paraspinal nerves",PNF
-7316-2090,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,Initial CNS Tumor,#220040,Embryonal tumor,3,Atypical Teratoid Rhabdoid Tumor,ATRT,Embryonal tumor,ATRT
-7316-2091,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Progressive,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-2092,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Progressive,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-2099,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-2100,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Progressive,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-2106,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-2107,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-2109,Ependymal tumor,Ependymoma,Progressive,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-2110,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,Initial CNS Tumor,#220040,Embryonal tumor,3,Atypical Teratoid Rhabdoid Tumor,ATRT,Embryonal tumor,ATRT
-7316-2118,Embryonal tumor,Medulloblastoma,Progressive,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-2125,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-2130,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Progressive,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-2133,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-2134,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-2135,Low-grade astrocytic tumor,Pleomorphic xanthoastrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pleomorphic xanthoastrocytoma,PXA,Low-grade glioma,PXA
-7316-2138,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-214,Meningioma,Meningioma,Initial CNS Tumor,#2db398,Meningioma,8,Meningioma,Meningioma,Meningioma,Meningioma
-7316-2140,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Progressive,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-2141,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,Initial CNS Tumor,#220040,Embryonal tumor,3,Atypical Teratoid Rhabdoid Tumor,ATRT,Embryonal tumor,ATRT
-7316-2142,Meningioma,Meningioma,Second Malignancy,#2db398,Meningioma,8,Meningioma,Meningioma,Meningioma,Meningioma
-7316-2144,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-2146,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Progressive,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-2147,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Progressive,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-2148,Meningioma,Meningioma,Second Malignancy,#2db398,Meningioma,8,Meningioma,Meningioma,Meningioma,Meningioma
-7316-2149,Germ cell tumor,Germinoma,Initial CNS Tumor,#0074d9,Germ cell tumor,10,Other,Other,Germ cell tumor,Other
-7316-2150,Mesenchymal non-meningothelial tumor,Ewing sarcoma,Initial CNS Tumor,#7fbf00,Mesenchymal non-meningothelial tumor,9,Ewing sarcoma,EWS,"Mesenchymal non-
-meningothelial tumor",EWS
-7316-2151,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Progressive,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-2152,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-2153,Mesenchymal non-meningothelial tumor,Sarcoma,Initial CNS Tumor,#7fbf00,Mesenchymal non-meningothelial tumor,9,Other,Other,"Mesenchymal non-
-meningothelial tumor",Other
-7316-2154,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Recurrence,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-2155,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-2156,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-2157,Tumors of sellar region,Craniopharyngioma,Initial CNS Tumor,#b2502d,Tumor of sellar region,7,Craniopharyngioma,CRANIO,Tumor of sellar region,CRANIO
-7316-2158,Tumors of sellar region,Craniopharyngioma,Initial CNS Tumor,#b2502d,Tumor of sellar region,7,Craniopharyngioma,CRANIO,Tumor of sellar region,CRANIO
-7316-2159,Tumor of cranial and paraspinal nerves,Schwannoma,Recurrence,#ffaa00,Tumor of cranial and paraspinal nerves,5,Schwannoma,Schwannoma,"Tumor of cranial and
-paraspinal nerves",Schwannoma
-7316-216,Tumor of cranial and paraspinal nerves,Neurofibroma Plexiform,Initial CNS Tumor,#ffaa00,Tumor of cranial and paraspinal nerves,5,Neurofibroma Plexiform,PNF,"Tumor of cranial and
-paraspinal nerves",PNF
-7316-2166,Tumor of cranial and paraspinal nerves,Neurofibroma Plexiform,Progressive,#ffaa00,Tumor of cranial and paraspinal nerves,5,Neurofibroma Plexiform,PNF,"Tumor of cranial and
-paraspinal nerves",PNF
-7316-2167,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-2169,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-217,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Progressive,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-2170,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-2171,Low-grade astrocytic tumor,Subependymal Giant Cell Astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Subependymal Giant Cell Astrocytoma,SEGA,Low-grade glioma,SEGA
-7316-2172,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-2174,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-2176,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-2177,Meningioma,Meningioma,Initial CNS Tumor,#2db398,Meningioma,8,Meningioma,Meningioma,Meningioma,Meningioma
-7316-2178,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-2180,Mesenchymal non-meningothelial tumor,Sarcoma,Initial CNS Tumor,#7fbf00,Mesenchymal non-meningothelial tumor,9,Other,Other,"Mesenchymal non-
-meningothelial tumor",Other
-7316-2181,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,Initial CNS Tumor,#220040,Embryonal tumor,3,Atypical Teratoid Rhabdoid Tumor,ATRT,Embryonal tumor,ATRT
-7316-2182,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-2183,Tumors of sellar region,Craniopharyngioma,Initial CNS Tumor,#b2502d,Tumor of sellar region,7,Craniopharyngioma,CRANIO,Tumor of sellar region,CRANIO
-7316-2184,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-2186,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,Initial CNS Tumor,#220040,Embryonal tumor,3,Atypical Teratoid Rhabdoid Tumor,ATRT,Embryonal tumor,ATRT
-7316-2187,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,Initial CNS Tumor,#220040,Embryonal tumor,3,Atypical Teratoid Rhabdoid Tumor,ATRT,Embryonal tumor,ATRT
-7316-2189,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Progressive,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-219,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-2191,Meningioma,Meningioma,Initial CNS Tumor,#2db398,Meningioma,8,Meningioma,Meningioma,Meningioma,Meningioma
-7316-2193,Low-grade astrocytic tumor,Pilocytic astrocytoma,Progressive,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-2195,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-2196,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-2197,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-22,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-220,Benign tumor,Choroid plexus papilloma,Initial CNS Tumor,#590024,Benign tumor,11,Choroid plexus papilloma,CPP,Benign tumor,CPP
-7316-2202,Germ cell tumor,Teratoma,Progressive,#0074d9,Germ cell tumor,10,Teratoma,Teratoma,Germ cell tumor,Teratoma
-7316-2203,Low-grade astrocytic tumor,Ganglioglioma,Progressive,#8f8fbf,Low-grade glioma,1,Ganglioglioma,GNG,Low-grade glioma,GNG
-7316-2204,Neuronal and mixed neuronal-glial tumor,Glial-neuronal tumor NOS,Initial CNS Tumor,#685815,Neuronal and mixed neuronal-glial tumor,6,Other,Other,"Neuronal and mixed
-neuronal-glial tumor",Other
-7316-2208,Neuronal and mixed neuronal-glial tumor,Diffuse leptomeningeal glioneuronal tumor,Progressive,#685815,Neuronal and mixed neuronal-glial tumor,6,Other,Other,"Neuronal and mixed
-neuronal-glial tumor",Other
-7316-221,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-2215,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-2216,Low-grade astrocytic tumor,Ganglioglioma,Progressive,#8f8fbf,Low-grade glioma,1,Ganglioglioma,GNG,Low-grade glioma,GNG
-7316-2217,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-222,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-2221,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-2224,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,Initial CNS Tumor,#220040,Embryonal tumor,3,Atypical Teratoid Rhabdoid Tumor,ATRT,Embryonal tumor,ATRT
-7316-2227,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-2228,Low-grade astrocytic tumor,Ganglioglioma,Progressive,#8f8fbf,Low-grade glioma,1,Ganglioglioma,GNG,Low-grade glioma,GNG
-7316-223,Tumor of cranial and paraspinal nerves,Neurofibroma Plexiform,Initial CNS Tumor,#ffaa00,Tumor of cranial and paraspinal nerves,5,Neurofibroma Plexiform,PNF,"Tumor of cranial and
-paraspinal nerves",PNF
-7316-2230,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-2237,Diffuse astrocytic and oligodendroglial tumor,Oligodendroglioma,Recurrence,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-224,Embryonal tumor,Neuroblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Other embryonal tumor,Other ET,Embryonal tumor,Other ET
-7316-2240,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-2241,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-2243,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-2244,Benign tumor,Choroid plexus papilloma,Initial CNS Tumor,#590024,Benign tumor,11,Choroid plexus papilloma,CPP,Benign tumor,CPP
-7316-2245,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-2248,Choroid plexus tumor,Choroid plexus carcinoma,Initial CNS Tumor,#808080,Other,12,Other,Other,Other,Other
-7316-2249,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-225,Metastatic tumors,Metastatic secondary tumors,Initial CNS Tumor,#808080,Other,12,Other,Other,Other,Other
-7316-2250,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-2251,Benign tumor,Choroid plexus papilloma,Initial CNS Tumor,#590024,Benign tumor,11,Choroid plexus papilloma,CPP,Benign tumor,CPP
-7316-2252,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-2255,Low-grade astrocytic tumor,Ganglioglioma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Ganglioglioma,GNG,Low-grade glioma,GNG
-7316-226,Tumors of sellar region,Craniopharyngioma,Initial CNS Tumor,#b2502d,Tumor of sellar region,7,Craniopharyngioma,CRANIO,Tumor of sellar region,CRANIO
-7316-2266,Ependymal tumor,Ependymoma,Progressive,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-2267,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-2268,Germ cell tumor,Teratoma,Initial CNS Tumor,#0074d9,Germ cell tumor,10,Teratoma,Teratoma,Germ cell tumor,Teratoma
-7316-2269,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,Initial CNS Tumor,#220040,Embryonal tumor,3,Atypical Teratoid Rhabdoid Tumor,ATRT,Embryonal tumor,ATRT
-7316-2271,Mesenchymal non-meningothelial tumor,Sarcoma,Recurrence,#7fbf00,Mesenchymal non-meningothelial tumor,9,Other,Other,"Mesenchymal non-
-meningothelial tumor",Other
-7316-2274,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-2275,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-2276,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,Progressive,#220040,Embryonal tumor,3,Atypical Teratoid Rhabdoid Tumor,ATRT,Embryonal tumor,ATRT
-7316-2278,Ependymal tumor,Ependymoma,Recurrence,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-2285,Neuronal and mixed neuronal-glial tumor,Glial-neuronal tumor NOS,Recurrence,#685815,Neuronal and mixed neuronal-glial tumor,6,Other,Other,"Neuronal and mixed
-neuronal-glial tumor",Other
-7316-2287,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-2288,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Recurrence,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-2291,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-23,Embryonal tumor,Neuroblastoma,Recurrence,#220040,Embryonal tumor,3,Other embryonal tumor,Other ET,Embryonal tumor,Other ET
-7316-230,Low-grade astrocytic tumor,Ganglioglioma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Ganglioglioma,GNG,Low-grade glioma,GNG
-7316-2300,Low-grade astrocytic tumor,Ganglioglioma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Ganglioglioma,GNG,Low-grade glioma,GNG
-7316-2305,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-2306,Low-grade astrocytic tumor,Ganglioglioma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Ganglioglioma,GNG,Low-grade glioma,GNG
-7316-2307,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-2308,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-2309,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-231,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Progressive,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-2310,Low-grade astrocytic tumor,Pleomorphic xanthoastrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pleomorphic xanthoastrocytoma,PXA,Low-grade glioma,PXA
-7316-2311,Tumors of sellar region,Craniopharyngioma,Initial CNS Tumor,#b2502d,Tumor of sellar region,7,Craniopharyngioma,CRANIO,Tumor of sellar region,CRANIO
-7316-2313,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-2322,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-2324,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-2329,Tumor of cranial and paraspinal nerves,Neurofibroma Plexiform,Initial CNS Tumor,#ffaa00,Tumor of cranial and paraspinal nerves,5,Neurofibroma Plexiform,PNF,"Tumor of cranial and
-paraspinal nerves",PNF
-7316-234,Tumor of cranial and paraspinal nerves,Neurofibroma Plexiform,Initial CNS Tumor,#ffaa00,Tumor of cranial and paraspinal nerves,5,Neurofibroma Plexiform,PNF,"Tumor of cranial and
-paraspinal nerves",PNF
-7316-235,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-238,Embryonal tumor,Embryonal tumor with multilayer rosettes,Progressive,#220040,Embryonal tumor,3,Other embryonal tumor,Other ET,Embryonal tumor,Other ET
-7316-240,Tumor of cranial and paraspinal nerves,Neurofibroma Plexiform,Initial CNS Tumor,#ffaa00,Tumor of cranial and paraspinal nerves,5,Neurofibroma Plexiform,PNF,"Tumor of cranial and
-paraspinal nerves",PNF
-7316-242,Meningioma,Meningioma,Second Malignancy,#2db398,Meningioma,8,Meningioma,Meningioma,Meningioma,Meningioma
-7316-245,Benign tumor,Choroid plexus papilloma,Initial CNS Tumor,#590024,Benign tumor,11,Choroid plexus papilloma,CPP,Benign tumor,CPP
-7316-247,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-249,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-2536,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Progressive,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-255,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-2554,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Progressive,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-2556,Ependymal tumor,Ependymoma,Recurrence,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-2557,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-2558,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-2561,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Recurrence,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-2562,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-2566,Low-grade astrocytic tumor,Pilocytic astrocytoma,Recurrence,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-2567,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-2569,Non-CNS tumor,Myxoid spindle cell tumor,Initial CNS Tumor,#808080,Other,12,Other,Other,Other,Other
-7316-257,Benign tumor,Choroid plexus papilloma,Initial CNS Tumor,#590024,Benign tumor,11,Choroid plexus papilloma,CPP,Benign tumor,CPP
-7316-2571,Low-grade astrocytic tumor,Ganglioglioma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Ganglioglioma,GNG,Low-grade glioma,GNG
-7316-2572,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-2575,Low-grade astrocytic tumor,Ganglioglioma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Ganglioglioma,GNG,Low-grade glioma,GNG
-7316-2576,Tumor of cranial and paraspinal nerves,Malignant peripheral nerve sheath tumor,Recurrence,#ffaa00,Tumor of cranial and paraspinal nerves,5,Other,Other,"Tumor of cranial and
-paraspinal nerves",Other
-7316-2577,Embryonal tumor,Embryonal tumor with multilayer rosettes,Recurrence,#220040,Embryonal tumor,3,Other embryonal tumor,Other ET,Embryonal tumor,Other ET
-7316-2578,Low-grade astrocytic tumor,Subependymal Giant Cell Astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Subependymal Giant Cell Astrocytoma,SEGA,Low-grade glioma,SEGA
-7316-258,Tumors of sellar region,Craniopharyngioma,Initial CNS Tumor,#b2502d,Tumor of sellar region,7,Craniopharyngioma,CRANIO,Tumor of sellar region,CRANIO
-7316-2581,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-2582,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,Initial CNS Tumor,#220040,Embryonal tumor,3,Atypical Teratoid Rhabdoid Tumor,ATRT,Embryonal tumor,ATRT
-7316-2583,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Progressive,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-2588,Meningioma,Meningioma,Second Malignancy,#2db398,Meningioma,8,Meningioma,Meningioma,Meningioma,Meningioma
-7316-2589,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-259,Low-grade astrocytic tumor,Ganglioglioma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Ganglioglioma,GNG,Low-grade glioma,GNG
-7316-2590,Tumor of cranial and paraspinal nerves,Neurofibroma Plexiform,Initial CNS Tumor,#ffaa00,Tumor of cranial and paraspinal nerves,5,Neurofibroma Plexiform,PNF,"Tumor of cranial and
-paraspinal nerves",PNF
-7316-2591,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-2594,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-2599,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Recurrence,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-2608,Germ cell tumor,Germinoma,Initial CNS Tumor,#0074d9,Germ cell tumor,10,Other,Other,Germ cell tumor,Other
-7316-2609,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-261,Low-grade astrocytic tumor,Ganglioglioma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Ganglioglioma,GNG,Low-grade glioma,GNG
-7316-2610,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-2614,Mesenchymal non-meningothelial tumor,Myofibroblastoma,Progressive,#7fbf00,Mesenchymal non-meningothelial tumor,9,Other,Other,"Mesenchymal non-
-meningothelial tumor",Other
-7316-262,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-2622,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-2626,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-2628,Low-grade astrocytic tumor,Ganglioglioma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Ganglioglioma,GNG,Low-grade glioma,GNG
-7316-263,Meningioma,Meningioma,Recurrence,#2db398,Meningioma,8,Meningioma,Meningioma,Meningioma,Meningioma
-7316-2632,Low-grade astrocytic tumor,Pilocytic astrocytoma,Progressive,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-264,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Progressive,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-2640,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-2641,Histiocytic tumor,Juvenile xanthogranuloma,Initial CNS Tumor,#808080,Other,12,Other,Other,Other,Other
-7316-2642,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-2647,Germ cell tumor,Teratoma,Progressive,#0074d9,Germ cell tumor,10,Teratoma,Teratoma,Germ cell tumor,Teratoma
-7316-2648,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-265,Low-grade astrocytic tumor,Pilocytic astrocytoma,Progressive,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-2653,Histiocytic tumor,Langerhans Cell histiocytosis,Initial CNS Tumor,#808080,Other,12,Other,Other,Other,Other
-7316-2658,Embryonal tumor,Embryonal tumor with multilayer rosettes,Initial CNS Tumor,#220040,Embryonal tumor,3,Other embryonal tumor,Other ET,Embryonal tumor,Other ET
-7316-2659,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-2660,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Recurrence,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-2661,Ependymal tumor,Ependymoma,Recurrence,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-2662,Germ cell tumor,Germinoma,Initial CNS Tumor,#0074d9,Germ cell tumor,10,Other,Other,Germ cell tumor,Other
-7316-2663,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-2664,Low-grade astrocytic tumor,Pleomorphic xanthoastrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pleomorphic xanthoastrocytoma,PXA,Low-grade glioma,PXA
-7316-2665,Tumor of cranial and paraspinal nerves,Neurofibroma Plexiform,Initial CNS Tumor,#ffaa00,Tumor of cranial and paraspinal nerves,5,Neurofibroma Plexiform,PNF,"Tumor of cranial and
-paraspinal nerves",PNF
-7316-2666,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-2667,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Progressive,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-2668,Choroid plexus tumor,Choroid plexus cyst,Initial CNS Tumor,#808080,Other,12,Other,Other,Other,Other
-7316-2669,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-267,Low-grade astrocytic tumor,Diffuse fibrillary astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-2671,Tumors of sellar region,Craniopharyngioma,Initial CNS Tumor,#b2502d,Tumor of sellar region,7,Craniopharyngioma,CRANIO,Tumor of sellar region,CRANIO
-7316-2672,Benign tumor,Choroid plexus papilloma,Initial CNS Tumor,#590024,Benign tumor,11,Choroid plexus papilloma,CPP,Benign tumor,CPP
-7316-2673,Meningioma,Meningioma,Initial CNS Tumor,#2db398,Meningioma,8,Meningioma,Meningioma,Meningioma,Meningioma
-7316-2680,Low-grade astrocytic tumor,Ganglioglioma,Recurrence,#8f8fbf,Low-grade glioma,1,Ganglioglioma,GNG,Low-grade glioma,GNG
-7316-2686,Mesenchymal non-meningothelial tumor,Ewing sarcoma,Initial CNS Tumor,#7fbf00,Mesenchymal non-meningothelial tumor,9,Ewing sarcoma,EWS,"Mesenchymal non-
-meningothelial tumor",EWS
-7316-2688,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,Initial CNS Tumor,#220040,Embryonal tumor,3,Atypical Teratoid Rhabdoid Tumor,ATRT,Embryonal tumor,ATRT
-7316-2689,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-2691,Low-grade astrocytic tumor,Ganglioglioma,Progressive,#8f8fbf,Low-grade glioma,1,Ganglioglioma,GNG,Low-grade glioma,GNG
-7316-2699,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-2703,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-2707,Tumor of pineal region,Pineoblastoma,Initial CNS Tumor,#808080,Other,12,Other,Other,Other,Other
-7316-2708,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-2719,Tumor of cranial and paraspinal nerves,Neurofibroma Plexiform,Initial CNS Tumor,#ffaa00,Tumor of cranial and paraspinal nerves,5,Neurofibroma Plexiform,PNF,"Tumor of cranial and
-paraspinal nerves",PNF
-7316-272,Embryonal tumor,Embryonal tumor with multilayer rosettes,Initial CNS Tumor,#220040,Embryonal tumor,3,Other embryonal tumor,Other ET,Embryonal tumor,Other ET
-7316-2723,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-2724,Mesenchymal non-meningothelial tumor,Fibromyxoid lesion,Second Malignancy,#7fbf00,Mesenchymal non-meningothelial tumor,9,Other,Other,"Mesenchymal non-
-meningothelial tumor",Other
-7316-2725,Low-grade astrocytic tumor,Pilocytic astrocytoma,Progressive,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-2729,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-2732,Meningioma,Meningioma,Initial CNS Tumor,#2db398,Meningioma,8,Meningioma,Meningioma,Meningioma,Meningioma
-7316-2737,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Progressive,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-2744,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Progressive,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-275,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-2751,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Progressive,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-2752,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Progressive,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-2753,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Progressive,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-2754,Tumor of cranial and paraspinal nerves,Neurofibroma Plexiform,Initial CNS Tumor,#ffaa00,Tumor of cranial and paraspinal nerves,5,Neurofibroma Plexiform,PNF,"Tumor of cranial and
-paraspinal nerves",PNF
-7316-2755,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-2756,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-2757,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-2758,Ependymal tumor,Ependymoma,Progressive,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-2760,Low-grade astrocytic tumor,Ganglioglioma,Recurrence,#8f8fbf,Low-grade glioma,1,Ganglioglioma,GNG,Low-grade glioma,GNG
-7316-2777,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-2779,Germ cell tumor,Teratoma,Initial CNS Tumor,#0074d9,Germ cell tumor,10,Teratoma,Teratoma,Germ cell tumor,Teratoma
-7316-278,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-2780,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-2782,Meningioma,Meningioma,Initial CNS Tumor,#2db398,Meningioma,8,Meningioma,Meningioma,Meningioma,Meningioma
-7316-279,Meningioma,Meningioma,Progressive,#2db398,Meningioma,8,Meningioma,Meningioma,Meningioma,Meningioma
-7316-280,Neuronal and mixed neuronal-glial tumor,Neurocytoma,Initial CNS Tumor,#685815,Neuronal and mixed neuronal-glial tumor,6,Other,Other,"Neuronal and mixed
-neuronal-glial tumor",Other
-7316-2809,Low-grade astrocytic tumor,Ganglioglioma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Ganglioglioma,GNG,Low-grade glioma,GNG
-7316-2810,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Progressive,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-2811,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-2857,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-2858,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-286,Tumor of cranial and paraspinal nerves,Neurofibroma Plexiform,Initial CNS Tumor,#ffaa00,Tumor of cranial and paraspinal nerves,5,Neurofibroma Plexiform,PNF,"Tumor of cranial and
-paraspinal nerves",PNF
-7316-2860,Benign tumor,Choroid plexus papilloma,Initial CNS Tumor,#590024,Benign tumor,11,Choroid plexus papilloma,CPP,Benign tumor,CPP
-7316-2862,Neuronal and mixed neuronal-glial tumor,Dysembryoplastic neuroepithelial tumor,Initial CNS Tumor,#685815,Neuronal and mixed neuronal-glial tumor,6,Dysembryoplastic neuroepithelial tumor,DNET,"Neuronal and mixed
-neuronal-glial tumor",DNET
-7316-2864,Neuronal and mixed neuronal-glial tumor,Glial-neuronal tumor NOS,Recurrence,#685815,Neuronal and mixed neuronal-glial tumor,6,Other,Other,"Neuronal and mixed
-neuronal-glial tumor",Other
-7316-2865,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-287,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-288,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-2893,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-2897,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-2899,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-29,Tumor of cranial and paraspinal nerves,Schwannoma,Initial CNS Tumor,#ffaa00,Tumor of cranial and paraspinal nerves,5,Schwannoma,Schwannoma,"Tumor of cranial and
-paraspinal nerves",Schwannoma
-7316-290,Low-grade astrocytic tumor,Subependymal Giant Cell Astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Subependymal Giant Cell Astrocytoma,SEGA,Low-grade glioma,SEGA
-7316-2901,Low-grade astrocytic tumor,Ganglioglioma,Progressive,#8f8fbf,Low-grade glioma,1,Ganglioglioma,GNG,Low-grade glioma,GNG
-7316-291,Tumor of cranial and paraspinal nerves,Schwannoma,Initial CNS Tumor,#ffaa00,Tumor of cranial and paraspinal nerves,5,Schwannoma,Schwannoma,"Tumor of cranial and
-paraspinal nerves",Schwannoma
-7316-292,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-2933,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,Progressive,#220040,Embryonal tumor,3,Atypical Teratoid Rhabdoid Tumor,ATRT,Embryonal tumor,ATRT
-7316-2934,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-2935,Chordoma,Chordoma,Progressive,#808080,Other,12,Other,Other,Other,Other
-7316-294,Mesenchymal non-meningothelial tumor,Sarcoma,Second Malignancy,#7fbf00,Mesenchymal non-meningothelial tumor,9,Other,Other,"Mesenchymal non-
-meningothelial tumor",Other
-7316-2959,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-2961,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-2962,Low-grade astrocytic tumor,Diffuse fibrillary astrocytoma,Recurrence,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-2966,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-297,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-2970,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Progressive,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-2971,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-2972,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-2980,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-2984,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-2986,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-2987,Embryonal tumor,CNS Embryonal tumor,Initial CNS Tumor,#220040,Embryonal tumor,3,Other embryonal tumor,Other ET,Embryonal tumor,Other ET
-7316-2988,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-2989,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-2990,Low-grade astrocytic tumor,Pleomorphic xanthoastrocytoma,Progressive,#8f8fbf,Low-grade glioma,1,Pleomorphic xanthoastrocytoma,PXA,Low-grade glioma,PXA
-7316-3,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-30,Tumor of cranial and paraspinal nerves,Schwannoma,Initial CNS Tumor,#ffaa00,Tumor of cranial and paraspinal nerves,5,Schwannoma,Schwannoma,"Tumor of cranial and
-paraspinal nerves",Schwannoma
-7316-3000,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Progressive,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-3010,Embryonal tumor,Medulloblastoma,Progressive,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-3017,Mesenchymal non-meningothelial tumor,Cavernoma,Initial CNS Tumor,#7fbf00,Mesenchymal non-meningothelial tumor,9,Other,Other,"Mesenchymal non-
-meningothelial tumor",Other
-7316-3019,Low-grade astrocytic tumor,Subependymal Giant Cell Astrocytoma,Progressive,#8f8fbf,Low-grade glioma,1,Subependymal Giant Cell Astrocytoma,SEGA,Low-grade glioma,SEGA
-7316-302,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-3020,Tumors of sellar region,Craniopharyngioma,Initial CNS Tumor,#b2502d,Tumor of sellar region,7,Craniopharyngioma,CRANIO,Tumor of sellar region,CRANIO
-7316-3022,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Progressive,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-3023,Embryonal tumor,Medulloblastoma,Progressive,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-3025,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-3028,Tumor of cranial and paraspinal nerves,Neurofibroma Plexiform,Initial CNS Tumor,#ffaa00,Tumor of cranial and paraspinal nerves,5,Neurofibroma Plexiform,PNF,"Tumor of cranial and
-paraspinal nerves",PNF
-7316-3029,Tumor of cranial and paraspinal nerves,Schwannoma,Initial CNS Tumor,#ffaa00,Tumor of cranial and paraspinal nerves,5,Schwannoma,Schwannoma,"Tumor of cranial and
-paraspinal nerves",Schwannoma
-7316-3030,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-304,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-3040,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-3045,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,Progressive,#220040,Embryonal tumor,3,Atypical Teratoid Rhabdoid Tumor,ATRT,Embryonal tumor,ATRT
-7316-3048,Neuronal and mixed neuronal-glial tumor,Dysembryoplastic neuroepithelial tumor,Initial CNS Tumor,#685815,Neuronal and mixed neuronal-glial tumor,6,Dysembryoplastic neuroepithelial tumor,DNET,"Neuronal and mixed
-neuronal-glial tumor",DNET
-7316-305,Embryonal tumor,Medulloblastoma,Recurrence,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-3052,Neuronal and mixed neuronal-glial tumor,Glial-neuronal tumor NOS,Initial CNS Tumor,#685815,Neuronal and mixed neuronal-glial tumor,6,Other,Other,"Neuronal and mixed
-neuronal-glial tumor",Other
-7316-3054,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-3055,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-3057,Germ cell tumor,Teratoma,Progressive,#0074d9,Germ cell tumor,10,Teratoma,Teratoma,Germ cell tumor,Teratoma
-7316-3058,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Progressive,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-306,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-3060,Low-grade astrocytic tumor,Ganglioglioma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Ganglioglioma,GNG,Low-grade glioma,GNG
-7316-3061,Low-grade astrocytic tumor,Pilocytic astrocytoma,Progressive,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-3062,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-3064,Neuronal and mixed neuronal-glial tumor,Glial-neuronal tumor NOS,Initial CNS Tumor,#685815,Neuronal and mixed neuronal-glial tumor,6,Other,Other,"Neuronal and mixed
-neuronal-glial tumor",Other
-7316-3065,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-3066,Tumor of cranial and paraspinal nerves,Malignant peripheral nerve sheath tumor,Initial CNS Tumor,#ffaa00,Tumor of cranial and paraspinal nerves,5,Other,Other,"Tumor of cranial and
-paraspinal nerves",Other
-7316-3067,Low-grade astrocytic tumor,Ganglioglioma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Ganglioglioma,GNG,Low-grade glioma,GNG
-7316-3068,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-3069,Ependymal tumor,Ependymoma,Progressive,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-307,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-3070,Tumors of sellar region,Craniopharyngioma,Initial CNS Tumor,#b2502d,Tumor of sellar region,7,Craniopharyngioma,CRANIO,Tumor of sellar region,CRANIO
-7316-3071,Tumors of sellar region,Craniopharyngioma,Recurrence,#b2502d,Tumor of sellar region,7,Craniopharyngioma,CRANIO,Tumor of sellar region,CRANIO
-7316-3072,Tumor of pineal region,Pineoblastoma,Initial CNS Tumor,#808080,Other,12,Other,Other,Other,Other
-7316-3074,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-3075,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-3076,Low-grade astrocytic tumor,Pilocytic astrocytoma,Progressive,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-309,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-310,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-312,Embryonal tumor,Medulloblastoma,Recurrence,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-3122,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-313,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-3132,Neuronal and mixed neuronal-glial tumor,Dysembryoplastic neuroepithelial tumor,Initial CNS Tumor,#685815,Neuronal and mixed neuronal-glial tumor,6,Dysembryoplastic neuroepithelial tumor,DNET,"Neuronal and mixed
-neuronal-glial tumor",DNET
-7316-3138,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-3139,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-314,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-3140,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-3147,Embryonal tumor,Ganglioneuroblastoma,Recurrence,#220040,Embryonal tumor,3,Other embryonal tumor,Other ET,Embryonal tumor,Other ET
-7316-3148,Melanocytic tumor,Melanocytic tumor,Initial CNS Tumor,#808080,Other,12,Other,Other,Other,Other
-7316-315,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-3150,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-3153,Non-tumor,Epilepsy,Initial CNS Tumor,#808080,Other,12,Other,Other,Other,Other
-7316-3154,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-3169,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-319,Low-grade astrocytic tumor,Ganglioglioma,Progressive,#8f8fbf,Low-grade glioma,1,Ganglioglioma,GNG,Low-grade glioma,GNG
-7316-3192,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-32,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-3202,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-3203,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-3204,Benign tumor,Choroid plexus papilloma,Initial CNS Tumor,#590024,Benign tumor,11,Choroid plexus papilloma,CPP,Benign tumor,CPP
-7316-3206,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-3208,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-321,Low-grade astrocytic tumor,Ganglioglioma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Ganglioglioma,GNG,Low-grade glioma,GNG
-7316-3212,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-3213,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-3214-A07082,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-3214-A07083,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-3215,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-3216,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-3217,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Progressive,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-3217,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-3218,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-3219,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-322,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-3220,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-3221,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-3222,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-3223,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-3224,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-3225,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-3227,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-3228,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Progressive,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-3229,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Progressive Disease Post-Mortem,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-323,Tumors of sellar region,Craniopharyngioma,Recurrence,#b2502d,Tumor of sellar region,7,Craniopharyngioma,CRANIO,Tumor of sellar region,CRANIO
-7316-3230,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Progressive Disease Post-Mortem,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-3230,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Progressive Disease Post-Mortem,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-3231,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Progressive Disease Post-Mortem,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-3232,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-3234,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Progressive,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-3235,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-3237,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Progressive Disease Post-Mortem,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-324,Low-grade astrocytic tumor,Ganglioglioma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Ganglioglioma,GNG,Low-grade glioma,GNG
-7316-3240,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-325,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Recurrence,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-329,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-3292,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-3295,Chordoma,Chordoma,Recurrence,#808080,Other,12,Other,Other,Other,Other
-7316-3299,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-33,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-330,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-3300,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-3303,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Progressive,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-3306,Histiocytic tumor,Langerhans Cell histiocytosis,Initial CNS Tumor,#808080,Other,12,Other,Other,Other,Other
-7316-3308,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-331,Meningioma,Meningioma,Initial CNS Tumor,#2db398,Meningioma,8,Meningioma,Meningioma,Meningioma,Meningioma
-7316-3311,Embryonal tumor,Neuroblastoma,Progressive,#220040,Embryonal tumor,3,Other embryonal tumor,Other ET,Embryonal tumor,Other ET
-7316-3312,Meningioma,Meningioma,Recurrence,#2db398,Meningioma,8,Meningioma,Meningioma,Meningioma,Meningioma
-7316-3316,Tumors of sellar region,Craniopharyngioma,Initial CNS Tumor,#b2502d,Tumor of sellar region,7,Craniopharyngioma,CRANIO,Tumor of sellar region,CRANIO
-7316-3319,Ependymal tumor,Ependymoma,Recurrence,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-332,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-3323,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-3326,Embryonal tumor,Embryonal tumor with multilayer rosettes,Initial CNS Tumor,#220040,Embryonal tumor,3,Other embryonal tumor,Other ET,Embryonal tumor,Other ET
-7316-333,Embryonal tumor,Medulloblastoma,Progressive,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-3336,Mesenchymal non-meningothelial tumor,Hemangioblastoma,Initial CNS Tumor,#7fbf00,Mesenchymal non-meningothelial tumor,9,Other,Other,"Mesenchymal non-
-meningothelial tumor",Other
-7316-334,Neuronal and mixed neuronal-glial tumor,Glial-neuronal tumor NOS,Initial CNS Tumor,#685815,Neuronal and mixed neuronal-glial tumor,6,Other,Other,"Neuronal and mixed
-neuronal-glial tumor",Other
-7316-3345,Low-grade astrocytic tumor,Ganglioglioma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Ganglioglioma,GNG,Low-grade glioma,GNG
-7316-340,Neuronal and mixed neuronal-glial tumor,Neurocytoma,Progressive,#685815,Neuronal and mixed neuronal-glial tumor,6,Other,Other,"Neuronal and mixed
-neuronal-glial tumor",Other
-7316-341,Tumors of sellar region,Craniopharyngioma,Initial CNS Tumor,#b2502d,Tumor of sellar region,7,Craniopharyngioma,CRANIO,Tumor of sellar region,CRANIO
-7316-343,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-344,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Progressive,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-345,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-346,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-347,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-3485,Benign tumor,Choroid plexus papilloma,Initial CNS Tumor,#590024,Benign tumor,11,Choroid plexus papilloma,CPP,Benign tumor,CPP
-7316-3488,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-349,Metastatic tumors,Metastatic secondary tumors,Initial CNS Tumor,#808080,Other,12,Other,Other,Other,Other
-7316-3491,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-35,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-350,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-3504,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-3510,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-3511,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-3512,Tumors of sellar region,Craniopharyngioma,Initial CNS Tumor,#b2502d,Tumor of sellar region,7,Craniopharyngioma,CRANIO,Tumor of sellar region,CRANIO
-7316-3513,Tumors of sellar region,Craniopharyngioma,Initial CNS Tumor,#b2502d,Tumor of sellar region,7,Craniopharyngioma,CRANIO,Tumor of sellar region,CRANIO
-7316-3515,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-3516,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-3520,Neuronal and mixed neuronal-glial tumor,Dysembryoplastic neuroepithelial tumor,Initial CNS Tumor,#685815,Neuronal and mixed neuronal-glial tumor,6,Dysembryoplastic neuroepithelial tumor,DNET,"Neuronal and mixed
-neuronal-glial tumor",DNET
-7316-3521,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Progressive,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-3522,Low-grade astrocytic tumor,Pilocytic astrocytoma,Progressive,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-3554,Low-grade astrocytic tumor,Subependymal Giant Cell Astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Subependymal Giant Cell Astrocytoma,SEGA,Low-grade glioma,SEGA
-7316-3555,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-3556,Low-grade astrocytic tumor,Pilocytic astrocytoma,Progressive,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-3557,Non-tumor,Arteriovenous malformation,Recurrence,#808080,Other,12,Other,Other,Other,Other
-7316-3558,Tumor of cranial and paraspinal nerves,Neurofibroma Plexiform,Progressive,#ffaa00,Tumor of cranial and paraspinal nerves,5,Neurofibroma Plexiform,PNF,"Tumor of cranial and
-paraspinal nerves",PNF
-7316-356,Tumor of cranial and paraspinal nerves,Malignant peripheral nerve sheath tumor,Initial CNS Tumor,#ffaa00,Tumor of cranial and paraspinal nerves,5,Other,Other,"Tumor of cranial and
-paraspinal nerves",Other
-7316-3566,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-3570,Low-grade astrocytic tumor,Pilocytic astrocytoma,Progressive,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-3571,Tumors of sellar region,Craniopharyngioma,Progressive,#b2502d,Tumor of sellar region,7,Craniopharyngioma,CRANIO,Tumor of sellar region,CRANIO
-7316-3572,Low-grade astrocytic tumor,Ganglioglioma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Ganglioglioma,GNG,Low-grade glioma,GNG
-7316-3574,Neuronal and mixed neuronal-glial tumor,Dysembryoplastic neuroepithelial tumor,Initial CNS Tumor,#685815,Neuronal and mixed neuronal-glial tumor,6,Dysembryoplastic neuroepithelial tumor,DNET,"Neuronal and mixed
-neuronal-glial tumor",DNET
-7316-3575,Low-grade astrocytic tumor,Pilocytic astrocytoma,Progressive,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-3576,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-358,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-359,Low-grade astrocytic tumor,Ganglioglioma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Ganglioglioma,GNG,Low-grade glioma,GNG
-7316-361,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-362,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-3621,Neuronal and mixed neuronal-glial tumor,Dysembryoplastic neuroepithelial tumor,Initial CNS Tumor,#685815,Neuronal and mixed neuronal-glial tumor,6,Dysembryoplastic neuroepithelial tumor,DNET,"Neuronal and mixed
-neuronal-glial tumor",DNET
-7316-3622,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-3623,Meningioma,Meningioma,Initial CNS Tumor,#2db398,Meningioma,8,Meningioma,Meningioma,Meningioma,Meningioma
-7316-3624,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-3625,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-3626,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-3627,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Recurrence,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-3628,Mesenchymal non-meningothelial tumor,Sarcoma,Recurrence,#7fbf00,Mesenchymal non-meningothelial tumor,9,Other,Other,"Mesenchymal non-
-meningothelial tumor",Other
-7316-3629,Neuronal and mixed neuronal-glial tumor,Glial-neuronal tumor NOS,Recurrence,#685815,Neuronal and mixed neuronal-glial tumor,6,Other,Other,"Neuronal and mixed
-neuronal-glial tumor",Other
-7316-3630,Neuronal and mixed neuronal-glial tumor,Glial-neuronal tumor NOS,Initial CNS Tumor,#685815,Neuronal and mixed neuronal-glial tumor,6,Other,Other,"Neuronal and mixed
-neuronal-glial tumor",Other
-7316-3631,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-3632,Chordoma,Chordoma,Initial CNS Tumor,#808080,Other,12,Other,Other,Other,Other
-7316-364,Mesenchymal non-meningothelial tumor,Ewing sarcoma,Initial CNS Tumor,#7fbf00,Mesenchymal non-meningothelial tumor,9,Ewing sarcoma,EWS,"Mesenchymal non-
-meningothelial tumor",EWS
-7316-365,Ependymal tumor,Ependymoma,Recurrence,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-367,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-368,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-3680,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,Progressive,#220040,Embryonal tumor,3,Atypical Teratoid Rhabdoid Tumor,ATRT,Embryonal tumor,ATRT
-7316-3689,Embryonal tumor,CNS neuroblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Other embryonal tumor,Other ET,Embryonal tumor,Other ET
-7316-370,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-371,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Progressive,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-373,Low-grade astrocytic tumor,Ganglioglioma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Ganglioglioma,GNG,Low-grade glioma,GNG
-7316-375,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-3751,Low-grade astrocytic tumor,Pilocytic astrocytoma,Progressive,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-3755,Ependymal tumor,Ependymoma,Recurrence,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-3756,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-376,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,Progressive,#220040,Embryonal tumor,3,Atypical Teratoid Rhabdoid Tumor,ATRT,Embryonal tumor,ATRT
-7316-3762,Low-grade astrocytic tumor,Pilocytic astrocytoma,Progressive,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-3765,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-3768,Neuronal and mixed neuronal-glial tumor,Dysembryoplastic neuroepithelial tumor,Initial CNS Tumor,#685815,Neuronal and mixed neuronal-glial tumor,6,Dysembryoplastic neuroepithelial tumor,DNET,"Neuronal and mixed
-neuronal-glial tumor",DNET
-7316-3769,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-377,Tumor of cranial and paraspinal nerves,Schwannoma,Progressive,#ffaa00,Tumor of cranial and paraspinal nerves,5,Schwannoma,Schwannoma,"Tumor of cranial and
-paraspinal nerves",Schwannoma
-7316-3771,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-3773,Tumors of sellar region,Craniopharyngioma,Initial CNS Tumor,#b2502d,Tumor of sellar region,7,Craniopharyngioma,CRANIO,Tumor of sellar region,CRANIO
-7316-3774,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-3775,Mesenchymal non-meningothelial tumor,Ewing sarcoma,Recurrence,#7fbf00,Mesenchymal non-meningothelial tumor,9,Ewing sarcoma,EWS,"Mesenchymal non-
-meningothelial tumor",EWS
-7316-3776,Tumor of cranial and paraspinal nerves,Neurofibroma Plexiform,Progressive,#ffaa00,Tumor of cranial and paraspinal nerves,5,Neurofibroma Plexiform,PNF,"Tumor of cranial and
-paraspinal nerves",PNF
-7316-378,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-38,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-380,Tumors of sellar region,Craniopharyngioma,Initial CNS Tumor,#b2502d,Tumor of sellar region,7,Craniopharyngioma,CRANIO,Tumor of sellar region,CRANIO
-7316-3809,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-381,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-3817,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-382,Meningioma,Meningioma,Recurrence,#2db398,Meningioma,8,Meningioma,Meningioma,Meningioma,Meningioma
-7316-384,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-3844,Embryonal tumor,CNS neuroblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Other embryonal tumor,Other ET,Embryonal tumor,Other ET
-7316-3846,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-3856,Tumor of pineal region,Pineoblastoma,Initial CNS Tumor,#808080,Other,12,Other,Other,Other,Other
-7316-3857,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-386,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,Initial CNS Tumor,#220040,Embryonal tumor,3,Atypical Teratoid Rhabdoid Tumor,ATRT,Embryonal tumor,ATRT
-7316-387,Tumors of sellar region,Craniopharyngioma,Initial CNS Tumor,#b2502d,Tumor of sellar region,7,Craniopharyngioma,CRANIO,Tumor of sellar region,CRANIO
-7316-388,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-389,Low-grade astrocytic tumor,Ganglioglioma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Ganglioglioma,GNG,Low-grade glioma,GNG
-7316-3890,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,Initial CNS Tumor,#220040,Embryonal tumor,3,Atypical Teratoid Rhabdoid Tumor,ATRT,Embryonal tumor,ATRT
-7316-3891,Tumors of sellar region,Craniopharyngioma,Progressive,#b2502d,Tumor of sellar region,7,Craniopharyngioma,CRANIO,Tumor of sellar region,CRANIO
-7316-3892,Germ cell tumor,Mixed germ cell tumor,Progressive,#0074d9,Germ cell tumor,10,Other,Other,Germ cell tumor,Other
-7316-3893,Ependymal tumor,Ependymoma,Progressive,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-39,Neuronal and mixed neuronal-glial tumor,Dysembryoplastic neuroepithelial tumor,Initial CNS Tumor,#685815,Neuronal and mixed neuronal-glial tumor,6,Dysembryoplastic neuroepithelial tumor,DNET,"Neuronal and mixed
-neuronal-glial tumor",DNET
-7316-390,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-391,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-3917,Low-grade astrocytic tumor,Ganglioglioma,Progressive,#8f8fbf,Low-grade glioma,1,Ganglioglioma,GNG,Low-grade glioma,GNG
-7316-3919,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-392,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-3920,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,Progressive,#220040,Embryonal tumor,3,Atypical Teratoid Rhabdoid Tumor,ATRT,Embryonal tumor,ATRT
-7316-3922,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-3923,Low-grade astrocytic tumor,Pleomorphic xanthoastrocytoma,Recurrence,#8f8fbf,Low-grade glioma,1,Pleomorphic xanthoastrocytoma,PXA,Low-grade glioma,PXA
-7316-393,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-3935,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-3936,Neuronal and mixed neuronal-glial tumor,Dysembryoplastic neuroepithelial tumor,Initial CNS Tumor,#685815,Neuronal and mixed neuronal-glial tumor,6,Dysembryoplastic neuroepithelial tumor,DNET,"Neuronal and mixed
-neuronal-glial tumor",DNET
-7316-3937,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,Initial CNS Tumor,#220040,Embryonal tumor,3,Atypical Teratoid Rhabdoid Tumor,ATRT,Embryonal tumor,ATRT
-7316-394,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-395,Low-grade astrocytic tumor,Ganglioglioma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Ganglioglioma,GNG,Low-grade glioma,GNG
-7316-3963,Tumor of cranial and paraspinal nerves,Schwannoma,Progressive,#ffaa00,Tumor of cranial and paraspinal nerves,5,Schwannoma,Schwannoma,"Tumor of cranial and
-paraspinal nerves",Schwannoma
-7316-397,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-398,Tumor of cranial and paraspinal nerves,Neurofibroma Plexiform,Initial CNS Tumor,#ffaa00,Tumor of cranial and paraspinal nerves,5,Neurofibroma Plexiform,PNF,"Tumor of cranial and
-paraspinal nerves",PNF
-7316-399,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Progressive,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-400,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-4028,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-4033,Embryonal tumor,Ganglioneuroblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Other embryonal tumor,Other ET,Embryonal tumor,Other ET
-7316-4034,Embryonal tumor,Ganglioneuroblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Other embryonal tumor,Other ET,Embryonal tumor,Other ET
-7316-4035,Ependymal tumor,Ependymoma,Recurrence,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-405,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-406,Choroid plexus tumor,Choroid plexus carcinoma,Initial CNS Tumor,#808080,Other,12,Other,Other,Other,Other
-7316-4062,Chordoma,Chordoma,Progressive,#808080,Other,12,Other,Other,Other,Other
-7316-407,Embryonal tumor,Medulloblastoma,Progressive,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-408,Germ cell tumor,Teratoma,Progressive,#0074d9,Germ cell tumor,10,Teratoma,Teratoma,Germ cell tumor,Teratoma
-7316-409,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-41,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,Initial CNS Tumor,#220040,Embryonal tumor,3,Atypical Teratoid Rhabdoid Tumor,ATRT,Embryonal tumor,ATRT
-7316-423,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-425,Ependymal tumor,Ependymoma,Progressive,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-429,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-430,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Recurrence,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-431,Choroid plexus tumor,Choroid plexus carcinoma,Initial CNS Tumor,#808080,Other,12,Other,Other,Other,Other
-7316-4341,Tumor of cranial and paraspinal nerves,Schwannoma,Initial CNS Tumor,#ffaa00,Tumor of cranial and paraspinal nerves,5,Schwannoma,Schwannoma,"Tumor of cranial and
-paraspinal nerves",Schwannoma
-7316-435,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-436,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-437,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-438,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-440,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-441,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-442,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Recurrence,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-443,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-4446,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-4447,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-4448,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Progressive,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-445,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-447,Embryonal tumor,Embryonal tumor with multilayer rosettes,Progressive,#220040,Embryonal tumor,3,Other embryonal tumor,Other ET,Embryonal tumor,Other ET
-7316-448,Tumor of cranial and paraspinal nerves,Schwannoma,Initial CNS Tumor,#ffaa00,Tumor of cranial and paraspinal nerves,5,Schwannoma,Schwannoma,"Tumor of cranial and
-paraspinal nerves",Schwannoma
-7316-449,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Progressive,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-451,Ependymal tumor,Ependymoma,Recurrence,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-452,Low-grade astrocytic tumor,Ganglioglioma,Progressive,#8f8fbf,Low-grade glioma,1,Ganglioglioma,GNG,Low-grade glioma,GNG
-7316-454,Ependymal tumor,Ependymoma,Progressive,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-455,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-456,Tumor of cranial and paraspinal nerves,Schwannoma,Initial CNS Tumor,#ffaa00,Tumor of cranial and paraspinal nerves,5,Schwannoma,Schwannoma,"Tumor of cranial and
-paraspinal nerves",Schwannoma
-7316-458,Mesenchymal non-meningothelial tumor,Ewing sarcoma,Initial CNS Tumor,#7fbf00,Mesenchymal non-meningothelial tumor,9,Ewing sarcoma,EWS,"Mesenchymal non-
-meningothelial tumor",EWS
-7316-459,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-46,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-460,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-461,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Progressive,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-462,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Recurrence,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-464,Embryonal tumor,CNS Embryonal tumor,Initial CNS Tumor,#220040,Embryonal tumor,3,Other embryonal tumor,Other ET,Embryonal tumor,Other ET
-7316-466,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-467,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-47,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-470,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-471,Benign tumor,Choroid plexus papilloma,Initial CNS Tumor,#590024,Benign tumor,11,Choroid plexus papilloma,CPP,Benign tumor,CPP
-7316-472,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-475,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-476,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-477,Meningioma,Meningioma,Recurrence,#2db398,Meningioma,8,Meningioma,Meningioma,Meningioma,Meningioma
-7316-479,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,Initial CNS Tumor,#220040,Embryonal tumor,3,Atypical Teratoid Rhabdoid Tumor,ATRT,Embryonal tumor,ATRT
-7316-480,Neuronal and mixed neuronal-glial tumor,Dysembryoplastic neuroepithelial tumor,Initial CNS Tumor,#685815,Neuronal and mixed neuronal-glial tumor,6,Dysembryoplastic neuroepithelial tumor,DNET,"Neuronal and mixed
-neuronal-glial tumor",DNET
-7316-482,Low-grade astrocytic tumor,Pilocytic astrocytoma,Progressive,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-485,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Progressive,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-487,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-488,Low-grade astrocytic tumor,Pilocytic astrocytoma,Progressive,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-489,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-490,Ependymal tumor,Ependymoma,Progressive,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-493,Histiocytic tumor,Langerhans Cell histiocytosis,Initial CNS Tumor,#808080,Other,12,Other,Other,Other,Other
-7316-495,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-496,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-497,Tumor of cranial and paraspinal nerves,Neurofibroma Plexiform,Second Malignancy,#ffaa00,Tumor of cranial and paraspinal nerves,5,Neurofibroma Plexiform,PNF,"Tumor of cranial and
-paraspinal nerves",PNF
-7316-499,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-4998,Diffuse astrocytic and oligodendroglial tumor,Diffuse intrinsic pontine glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse intrinsic pontine glioma,DIPG,High-grade glioma,DIPG
-7316-5,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-50,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-502,Neuronal and mixed neuronal-glial tumor,Desmoplastic infantile astrocytoma and ganglioglioma,Progressive,#685815,Neuronal and mixed neuronal-glial tumor,6,Other,Other,"Neuronal and mixed
-neuronal-glial tumor",Other
-7316-505,Embryonal tumor,CNS Embryonal tumor,Progressive,#220040,Embryonal tumor,3,Other embryonal tumor,Other ET,Embryonal tumor,Other ET
-7316-506,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-51,Neuronal and mixed neuronal-glial tumor,Dysembryoplastic neuroepithelial tumor,Progressive,#685815,Neuronal and mixed neuronal-glial tumor,6,Dysembryoplastic neuroepithelial tumor,DNET,"Neuronal and mixed
-neuronal-glial tumor",DNET
-7316-512,Embryonal tumor,CNS Embryonal tumor,Initial CNS Tumor,#220040,Embryonal tumor,3,Other embryonal tumor,Other ET,Embryonal tumor,Other ET
-7316-515,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-516,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-519,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-521,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-523,Meningioma,Meningioma,Initial CNS Tumor,#2db398,Meningioma,8,Meningioma,Meningioma,Meningioma,Meningioma
-7316-525,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,Initial CNS Tumor,#220040,Embryonal tumor,3,Atypical Teratoid Rhabdoid Tumor,ATRT,Embryonal tumor,ATRT
-7316-529,Embryonal tumor,CNS Embryonal tumor,Progressive,#220040,Embryonal tumor,3,Other embryonal tumor,Other ET,Embryonal tumor,Other ET
-7316-532,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-535,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-536,Embryonal tumor,CNS Embryonal tumor,Initial CNS Tumor,#220040,Embryonal tumor,3,Other embryonal tumor,Other ET,Embryonal tumor,Other ET
-7316-544,Diffuse astrocytic and oligodendroglial tumor,Diffuse intrinsic pontine glioma,Progressive,#ff80e5,High-grade glioma,2,Diffuse intrinsic pontine glioma,DIPG,High-grade glioma,DIPG
-7316-545,Diffuse astrocytic and oligodendroglial tumor,Diffuse intrinsic pontine glioma,Progressive,#ff80e5,High-grade glioma,2,Diffuse intrinsic pontine glioma,DIPG,High-grade glioma,DIPG
-7316-548,Diffuse astrocytic and oligodendroglial tumor,Diffuse intrinsic pontine glioma,Progressive,#ff80e5,High-grade glioma,2,Diffuse intrinsic pontine glioma,DIPG,High-grade glioma,DIPG
-7316-549,Diffuse astrocytic and oligodendroglial tumor,Diffuse intrinsic pontine glioma,Progressive,#ff80e5,High-grade glioma,2,Diffuse intrinsic pontine glioma,DIPG,High-grade glioma,DIPG
-7316-550,Diffuse astrocytic and oligodendroglial tumor,Diffuse intrinsic pontine glioma,Progressive,#ff80e5,High-grade glioma,2,Diffuse intrinsic pontine glioma,DIPG,High-grade glioma,DIPG
-7316-553,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-554,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-556,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-561,Tumors of sellar region,Craniopharyngioma,Initial CNS Tumor,#b2502d,Tumor of sellar region,7,Craniopharyngioma,CRANIO,Tumor of sellar region,CRANIO
-7316-562,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-6,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-612,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-619,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-620,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-622,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Recurrence,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-624,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-639,Diffuse astrocytic and oligodendroglial tumor,Diffuse intrinsic pontine glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse intrinsic pontine glioma,DIPG,High-grade glioma,DIPG
-7316-641,Tumor of cranial and paraspinal nerves,Schwannoma,Initial CNS Tumor,#ffaa00,Tumor of cranial and paraspinal nerves,5,Schwannoma,Schwannoma,"Tumor of cranial and
-paraspinal nerves",Schwannoma
-7316-642,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-643,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-644,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-658,Low-grade astrocytic tumor,Pilocytic astrocytoma,Progressive,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-659,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-663,Low-grade astrocytic tumor,Subependymal Giant Cell Astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Subependymal Giant Cell Astrocytoma,SEGA,Low-grade glioma,SEGA
-7316-666,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-670,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-676,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-677,Low-grade astrocytic tumor,Subependymal Giant Cell Astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Subependymal Giant Cell Astrocytoma,SEGA,Low-grade glioma,SEGA
-7316-681,Neuronal and mixed neuronal-glial tumor,Desmoplastic infantile astrocytoma and ganglioglioma,Initial CNS Tumor,#685815,Neuronal and mixed neuronal-glial tumor,6,Other,Other,"Neuronal and mixed
-neuronal-glial tumor",Other
-7316-692,Low-grade astrocytic tumor,Pleomorphic xanthoastrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pleomorphic xanthoastrocytoma,PXA,Low-grade glioma,PXA
-7316-70,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-71,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-714,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Recurrence,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-715,Diffuse astrocytic and oligodendroglial tumor,Diffuse intrinsic pontine glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse intrinsic pontine glioma,DIPG,High-grade glioma,DIPG
-7316-716,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-719,Diffuse astrocytic and oligodendroglial tumor,Diffuse intrinsic pontine glioma,Progressive,#ff80e5,High-grade glioma,2,Diffuse intrinsic pontine glioma,DIPG,High-grade glioma,DIPG
-7316-723,Choroid plexus tumor,Choroid plexus carcinoma,Initial CNS Tumor,#808080,Other,12,Other,Other,Other,Other
-7316-725,Benign tumor,Atypical choroid plexus papilloma,Progressive,#590024,Benign tumor,11,Other,Other,Benign tumor,Other
-7316-726,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-727,Meningioma,Meningioma,Initial CNS Tumor,#2db398,Meningioma,8,Meningioma,Meningioma,Meningioma,Meningioma
-7316-729,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-73,Histiocytic tumor,Langerhans Cell histiocytosis,Initial CNS Tumor,#808080,Other,12,Other,Other,Other,Other
-7316-733,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-735,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-736,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-737,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-739,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-740,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-741,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-746,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-747,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-749,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-76,Metastatic tumors,Metastatic secondary tumors,Initial CNS Tumor,#808080,Other,12,Other,Other,Other,Other
-7316-762,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-764,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-765,Embryonal tumor,CNS Embryonal tumor,Initial CNS Tumor,#220040,Embryonal tumor,3,Other embryonal tumor,Other ET,Embryonal tumor,Other ET
-7316-77,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-775,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-784,Embryonal tumor,Embryonal tumor with multilayer rosettes,Initial CNS Tumor,#220040,Embryonal tumor,3,Other embryonal tumor,Other ET,Embryonal tumor,Other ET
-7316-80,Neuronal and mixed neuronal-glial tumor,Dysembryoplastic neuroepithelial tumor,Initial CNS Tumor,#685815,Neuronal and mixed neuronal-glial tumor,6,Dysembryoplastic neuroepithelial tumor,DNET,"Neuronal and mixed
-neuronal-glial tumor",DNET
-7316-820,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,Initial CNS Tumor,#220040,Embryonal tumor,3,Atypical Teratoid Rhabdoid Tumor,ATRT,Embryonal tumor,ATRT
-7316-839,Embryonal tumor,Medulloblastoma,Progressive,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-84,Low-grade astrocytic tumor,Diffuse fibrillary astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-842,Embryonal tumor,Medulloblastoma,Recurrence,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-843,Embryonal tumor,Medulloblastoma,Recurrence,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-85,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-851,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-853,Benign tumor,Choroid plexus papilloma,Initial CNS Tumor,#590024,Benign tumor,11,Choroid plexus papilloma,CPP,Benign tumor,CPP
-7316-869,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-87,Embryonal tumor,CNS Embryonal tumor,Initial CNS Tumor,#220040,Embryonal tumor,3,Other embryonal tumor,Other ET,Embryonal tumor,Other ET
-7316-870,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Progressive,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-871,Embryonal tumor,CNS Embryonal tumor,Initial CNS Tumor,#220040,Embryonal tumor,3,Other embryonal tumor,Other ET,Embryonal tumor,Other ET
-7316-872,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-873,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-874,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-875,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-876,Mesenchymal non-meningothelial tumor,Ewing sarcoma,Initial CNS Tumor,#7fbf00,Mesenchymal non-meningothelial tumor,9,Ewing sarcoma,EWS,"Mesenchymal non-
-meningothelial tumor",EWS
-7316-877,Meningioma,Meningioma,Progressive,#2db398,Meningioma,8,Meningioma,Meningioma,Meningioma,Meningioma
-7316-878,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,Initial CNS Tumor,#220040,Embryonal tumor,3,Atypical Teratoid Rhabdoid Tumor,ATRT,Embryonal tumor,ATRT
-7316-88,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-880,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-882,Low-grade astrocytic tumor,Pilocytic astrocytoma,Progressive,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-883,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-884,Low-grade astrocytic tumor,Pleomorphic xanthoastrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pleomorphic xanthoastrocytoma,PXA,Low-grade glioma,PXA
-7316-889,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-89,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Progressive,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-891,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-892,Ependymal tumor,Ependymoma,Progressive,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-893,Low-grade astrocytic tumor,Ganglioglioma,Recurrence,#8f8fbf,Low-grade glioma,1,Ganglioglioma,GNG,Low-grade glioma,GNG
-7316-894,Germ cell tumor,Teratoma,Initial CNS Tumor,#0074d9,Germ cell tumor,10,Teratoma,Teratoma,Germ cell tumor,Teratoma
-7316-895,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Recurrence,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-896,Low-grade astrocytic tumor,Pilocytic astrocytoma,Recurrence,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-897,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-898,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Progressive,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-9,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-901,Meningioma,Meningioma,Second Malignancy,#2db398,Meningioma,8,Meningioma,Meningioma,Meningioma,Meningioma
-7316-903,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Recurrence,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-7316-905,Low-grade astrocytic tumor,Ganglioglioma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Ganglioglioma,GNG,Low-grade glioma,GNG
-7316-906,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-908,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-91,Low-grade astrocytic tumor,Ganglioglioma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Ganglioglioma,GNG,Low-grade glioma,GNG
-7316-913,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Second Malignancy,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-7316-914,Low-grade astrocytic tumor,Ganglioglioma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Ganglioglioma,GNG,Low-grade glioma,GNG
-7316-915,Neuronal and mixed neuronal-glial tumor,Dysembryoplastic neuroepithelial tumor,Initial CNS Tumor,#685815,Neuronal and mixed neuronal-glial tumor,6,Dysembryoplastic neuroepithelial tumor,DNET,"Neuronal and mixed
-neuronal-glial tumor",DNET
-7316-917,Low-grade astrocytic tumor,Pilocytic astrocytoma,Progressive,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-918,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,Initial CNS Tumor,#220040,Embryonal tumor,3,Atypical Teratoid Rhabdoid Tumor,ATRT,Embryonal tumor,ATRT
-7316-92,Mesenchymal non-meningothelial tumor,Cavernoma,Initial CNS Tumor,#7fbf00,Mesenchymal non-meningothelial tumor,9,Other,Other,"Mesenchymal non-
-meningothelial tumor",Other
-7316-921,Chordoma,Chordoma,Initial CNS Tumor,#808080,Other,12,Other,Other,Other,Other
-7316-922,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-923,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-924,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-925,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-929,Ependymal tumor,Ependymoma,Recurrence,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-93,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Progressive,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-931,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-932,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-934,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-935,Tumor of cranial and paraspinal nerves,Neurofibroma Plexiform,Second Malignancy,#ffaa00,Tumor of cranial and paraspinal nerves,5,Neurofibroma Plexiform,PNF,"Tumor of cranial and
-paraspinal nerves",PNF
-7316-936,Low-grade astrocytic tumor,Subependymal Giant Cell Astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Subependymal Giant Cell Astrocytoma,SEGA,Low-grade glioma,SEGA
-7316-937,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-938,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-94,Meningioma,Meningioma,Initial CNS Tumor,#2db398,Meningioma,8,Meningioma,Meningioma,Meningioma,Meningioma
-7316-944,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Recurrence,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-946,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-948,Tumor of cranial and paraspinal nerves,Schwannoma,Initial CNS Tumor,#ffaa00,Tumor of cranial and paraspinal nerves,5,Schwannoma,Schwannoma,"Tumor of cranial and
-paraspinal nerves",Schwannoma
-7316-949,Tumors of sellar region,Craniopharyngioma,Recurrence,#b2502d,Tumor of sellar region,7,Craniopharyngioma,CRANIO,Tumor of sellar region,CRANIO
-7316-95,Embryonal tumor,Medulloblastoma,Progressive,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-950,Embryonal tumor,CNS Embryonal tumor,Progressive,#220040,Embryonal tumor,3,Other embryonal tumor,Other ET,Embryonal tumor,Other ET
-7316-952,Neuronal and mixed neuronal-glial tumor,Dysembryoplastic neuroepithelial tumor,Initial CNS Tumor,#685815,Neuronal and mixed neuronal-glial tumor,6,Dysembryoplastic neuroepithelial tumor,DNET,"Neuronal and mixed
-neuronal-glial tumor",DNET
-7316-954,Low-grade astrocytic tumor,Pilocytic astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pilocytic astrocytoma,PA,Low-grade glioma,PA
-7316-956,Mesenchymal non-meningothelial tumor,Ewing sarcoma,Progressive,#7fbf00,Mesenchymal non-meningothelial tumor,9,Ewing sarcoma,EWS,"Mesenchymal non-
-meningothelial tumor",EWS
-7316-957,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-7316-96,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-965,Germ cell tumor,Teratoma,Initial CNS Tumor,#0074d9,Germ cell tumor,10,Teratoma,Teratoma,Germ cell tumor,Teratoma
-7316-966,Ependymal tumor,Ependymoma,Initial CNS Tumor,#2200ff,Ependymoma,4,Ependymoma,EPN,Ependymoma,EPN
-7316-968,Embryonal tumor,Medulloblastoma,Initial CNS Tumor,#220040,Embryonal tumor,3,Medulloblastoma,MB,Embryonal tumor,MB
-7316-97,Low-grade astrocytic tumor,Pleomorphic xanthoastrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Pleomorphic xanthoastrocytoma,PXA,Low-grade glioma,PXA
-7316-974,Low-grade astrocytic tumor,Low-grade glioma astrocytoma,Initial CNS Tumor,#8f8fbf,Low-grade glioma,1,Other low-grade glioma,Other LGG,Low-grade glioma,Other LGG
-A03942,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-A05262,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-A07082,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-A07150,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-A08692,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-A08732,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-A08768,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-A08958,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-A09410,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-A09446,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-A09576,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-A09689,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-A09985,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-A12398,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Progressive,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-A12748,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-A12911,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-A14449,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Progressive,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-A14565,Diffuse astrocytic and oligodendroglial tumor,High-grade glioma astrocytoma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Other high-grade glioma,Other HGG,High-grade glioma,Other HGG
-A14567,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-A14709,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-A15170,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-A15726,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-A16405,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-A16538,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-A16915,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-A17096,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-A17997,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-A18552,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-A18777,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-A19015,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-A19649,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
-A20091,Diffuse astrocytic and oligodendroglial tumor,Diffuse midline glioma,Initial CNS Tumor,#ff80e5,High-grade glioma,2,Diffuse midline glioma,DMG,High-grade glioma,DMG
+sample_id,cancer_group,tumor_descriptor,broad_histology_display,cancer_group_display,cancer_group_abbreviation
+7316-10,Neurofibroma Plexiform,Initial CNS Tumor,Tumor of cranial and paraspinal nerves,Neurofibroma Plexiform,PNF
+7316-100,Craniopharyngioma,Initial CNS Tumor,Tumor of sellar region,Craniopharyngioma,CRANIO
+7316-101,Ganglioglioma,Initial CNS Tumor,Low-grade glioma,Ganglioglioma,GNG
+7316-1038,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-104,Teratoma,Recurrence,Germ cell tumor,Teratoma,Teratoma
+7316-1052,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-1055,High-grade glioma astrocytoma,Second Malignancy,High-grade glioma,Other high-grade glioma,Other HGG
+7316-1057,High-grade glioma astrocytoma,Progressive,High-grade glioma,Other high-grade glioma,Other HGG
+7316-1059,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-1060,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-1062,High-grade glioma astrocytoma,Progressive,High-grade glioma,Other high-grade glioma,Other HGG
+7316-1064,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-1068,High-grade glioma astrocytoma,Progressive,High-grade glioma,Other high-grade glioma,Other HGG
+7316-1069,Adenoma,Initial CNS Tumor,Benign tumor,Other,Other
+7316-1070,Dysembryoplastic neuroepithelial tumor,Progressive,Neuronal and mixed neuronal-glial tumor,Dysembryoplastic neuroepithelial tumor,DNET
+7316-1071,Ganglioglioma,Recurrence,Low-grade glioma,Ganglioglioma,GNG
+7316-1073,Atypical Teratoid Rhabdoid Tumor,Initial CNS Tumor,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,ATRT
+7316-1075,Craniopharyngioma,Initial CNS Tumor,Tumor of sellar region,Craniopharyngioma,CRANIO
+7316-1077,Ganglioglioma,Initial CNS Tumor,Low-grade glioma,Ganglioglioma,GNG
+7316-1078,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-1079,Ewing sarcoma,Initial CNS Tumor,Mesenchymal non-meningothelial tumor,Ewing sarcoma,EWS
+7316-1080,Adenoma,Initial CNS Tumor,Benign tumor,Other,Other
+7316-1081,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-1082,Craniopharyngioma,Initial CNS Tumor,Tumor of sellar region,Craniopharyngioma,CRANIO
+7316-1083,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-1084,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-1085,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+7316-1086,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-1087,Subependymal Giant Cell Astrocytoma,Initial CNS Tumor,Low-grade glioma,Subependymal Giant Cell Astrocytoma,SEGA
+7316-1088,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-1089,Dysembryoplastic neuroepithelial tumor,Initial CNS Tumor,Neuronal and mixed neuronal-glial tumor,Dysembryoplastic neuroepithelial tumor,DNET
+7316-109,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-1090,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-1093,Dysembryoplastic neuroepithelial tumor,Initial CNS Tumor,Neuronal and mixed neuronal-glial tumor,Dysembryoplastic neuroepithelial tumor,DNET
+7316-1094,Schwannoma,Initial CNS Tumor,Tumor of cranial and paraspinal nerves,Schwannoma,Schwannoma
+7316-1095,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-1096,Adenoma,Initial CNS Tumor,Benign tumor,Other,Other
+7316-1099,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-1100,CNS Embryonal tumor,Recurrence,Embryonal tumor,Other embryonal tumor,Other ET
+7316-1101,Chordoma,Initial CNS Tumor,Other,Other,Other
+7316-1102,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+7316-1103,Choroid plexus papilloma,Initial CNS Tumor,Benign tumor,Choroid plexus papilloma,CPP
+7316-1104,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-1105,High-grade glioma astrocytoma,Recurrence,High-grade glioma,Other high-grade glioma,Other HGG
+7316-1106,Pleomorphic xanthoastrocytoma,Initial CNS Tumor,Low-grade glioma,Pleomorphic xanthoastrocytoma,PXA
+7316-1107,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-1108,Ganglioglioma,Initial CNS Tumor,Low-grade glioma,Ganglioglioma,GNG
+7316-1109,Rosette-forming glioneuronal tumor,Recurrence,Neuronal and mixed neuronal-glial tumor,Other,Other
+7316-111,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-1113,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-1114,Ganglioglioma,Initial CNS Tumor,Low-grade glioma,Ganglioglioma,GNG
+7316-1115,Teratoma,Initial CNS Tumor,Germ cell tumor,Teratoma,Teratoma
+7316-1116,Craniopharyngioma,Recurrence,Tumor of sellar region,Craniopharyngioma,CRANIO
+7316-1117,Dysembryoplastic neuroepithelial tumor,Recurrence,Neuronal and mixed neuronal-glial tumor,Dysembryoplastic neuroepithelial tumor,DNET
+7316-1118,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-1134,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-1137,Atypical Teratoid Rhabdoid Tumor,Initial CNS Tumor,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,ATRT
+7316-114,High-grade glioma astrocytoma,Second Malignancy,High-grade glioma,Other high-grade glioma,Other HGG
+7316-116,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+7316-117,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-1187,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-119,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-120,Ganglioglioma,Initial CNS Tumor,Low-grade glioma,Ganglioglioma,GNG
+7316-121,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-1214,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-122,Atypical Teratoid Rhabdoid Tumor,Initial CNS Tumor,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,ATRT
+7316-1226,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-124,Craniopharyngioma,Initial CNS Tumor,Tumor of sellar region,Craniopharyngioma,CRANIO
+7316-125,Neuroblastoma,Progressive,Embryonal tumor,Other embryonal tumor,Other ET
+7316-1252,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-126,Diffuse midline glioma,Progressive,High-grade glioma,Diffuse midline glioma,DMG
+7316-127,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-1279,Ependymoma,Recurrence,Ependymoma,Ependymoma,EPN
+7316-128,Ewing sarcoma,Progressive,Mesenchymal non-meningothelial tumor,Ewing sarcoma,EWS
+7316-129,Meningioma,Initial CNS Tumor,Meningioma,Meningioma,Meningioma
+7316-13,Neurofibroma Plexiform,Initial CNS Tumor,Tumor of cranial and paraspinal nerves,Neurofibroma Plexiform,PNF
+7316-1312,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-133,Oligodendroglioma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-134,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-135,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-136,Pleomorphic xanthoastrocytoma,Initial CNS Tumor,Low-grade glioma,Pleomorphic xanthoastrocytoma,PXA
+7316-14,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-1455,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-1459,Malignant peripheral nerve sheath tumor,Initial CNS Tumor,Tumor of cranial and paraspinal nerves,Other,Other
+7316-146,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-1460,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-1461,Meningioma,Initial CNS Tumor,Meningioma,Meningioma,Meningioma
+7316-1463,Schwannoma,Initial CNS Tumor,Tumor of cranial and paraspinal nerves,Schwannoma,Schwannoma
+7316-1464,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-147,Schwannoma,Initial CNS Tumor,Tumor of cranial and paraspinal nerves,Schwannoma,Schwannoma
+7316-1473,CNS neuroblastoma,Recurrence,Embryonal tumor,Other embryonal tumor,Other ET
+7316-1476,Meningioma,Progressive,Meningioma,Meningioma,Meningioma
+7316-148,Pilocytic astrocytoma,Recurrence,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-1480,Ependymoma,Progressive,Ependymoma,Ependymoma,EPN
+7316-152,Oligodendroglioma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-153,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-154,Low-grade glioma astrocytoma,Progressive,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-155,CNS Embryonal tumor,Initial CNS Tumor,Embryonal tumor,Other embryonal tumor,Other ET
+7316-156,Ganglioglioma,Progressive,Low-grade glioma,Ganglioglioma,GNG
+7316-157,Dysembryoplastic neuroepithelial tumor,Initial CNS Tumor,Neuronal and mixed neuronal-glial tumor,Dysembryoplastic neuroepithelial tumor,DNET
+7316-158,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-159,Schwannoma,Initial CNS Tumor,Tumor of cranial and paraspinal nerves,Schwannoma,Schwannoma
+7316-16,Metastatic secondary tumors,Initial CNS Tumor,Other,Other,Other
+7316-160,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-161,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-162,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-1635,Pleomorphic xanthoastrocytoma,Initial CNS Tumor,Low-grade glioma,Pleomorphic xanthoastrocytoma,PXA
+7316-1636,Ganglioglioma,Initial CNS Tumor,Low-grade glioma,Ganglioglioma,GNG
+7316-1637,Glial-neuronal tumor NOS,Initial CNS Tumor,Neuronal and mixed neuronal-glial tumor,Other,Other
+7316-164,Craniopharyngioma,Progressive,Tumor of sellar region,Craniopharyngioma,CRANIO
+7316-1641,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-1642,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-1643,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-1646,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-1648,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-1649,Rosai-Dorfman disease,Initial CNS Tumor,Other,Other,Other
+7316-1650,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-1651,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-1652,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-1653,Craniopharyngioma,Initial CNS Tumor,Tumor of sellar region,Craniopharyngioma,CRANIO
+7316-1654,Atypical choroid plexus papilloma,Initial CNS Tumor,Benign tumor,Other,Other
+7316-1655,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-1656,High-grade glioma astrocytoma,Recurrence,High-grade glioma,Other high-grade glioma,Other HGG
+7316-1658,Subependymal Giant Cell Astrocytoma,Initial CNS Tumor,Low-grade glioma,Subependymal Giant Cell Astrocytoma,SEGA
+7316-1659,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-166,Craniopharyngioma,Initial CNS Tumor,Tumor of sellar region,Craniopharyngioma,CRANIO
+7316-1660,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-1661,Low-grade glioma astrocytoma,Recurrence,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-1664,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-1666,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-1668,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-1669,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-167,Diffuse fibrillary astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-1670,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-1671,Craniopharyngioma,Initial CNS Tumor,Tumor of sellar region,Craniopharyngioma,CRANIO
+7316-1676,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-1677,Neurofibroma Plexiform,Initial CNS Tumor,Tumor of cranial and paraspinal nerves,Neurofibroma Plexiform,PNF
+7316-1678,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-1679,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-168,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-1680,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-1681,Subependymal Giant Cell Astrocytoma,Initial CNS Tumor,Low-grade glioma,Subependymal Giant Cell Astrocytoma,SEGA
+7316-1683,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-1693,Choroid plexus papilloma,Initial CNS Tumor,Benign tumor,Choroid plexus papilloma,CPP
+7316-1694,High-grade glioma astrocytoma,Progressive,High-grade glioma,Other high-grade glioma,Other HGG
+7316-1695,Diffuse intrinsic pontine glioma,Progressive,High-grade glioma,Diffuse intrinsic pontine glioma,DIPG
+7316-170,Neurofibroma Plexiform,Recurrence,Tumor of cranial and paraspinal nerves,Neurofibroma Plexiform,PNF
+7316-1700,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-1702,Meningioma,Initial CNS Tumor,Meningioma,Meningioma,Meningioma
+7316-1703,Meningioma,Second Malignancy,Meningioma,Meningioma,Meningioma
+7316-1704,Hemangioblastoma,Initial CNS Tumor,Mesenchymal non-meningothelial tumor,Other,Other
+7316-1705,Meningioma,Progressive,Meningioma,Meningioma,Meningioma
+7316-1706,Ependymoma,Progressive,Ependymoma,Ependymoma,EPN
+7316-1708,Diffuse midline glioma,Progressive,High-grade glioma,Diffuse midline glioma,DMG
+7316-1710,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-1711,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-1714,Medulloblastoma,Recurrence,Embryonal tumor,Medulloblastoma,MB
+7316-1715,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-1723,High-grade glioma astrocytoma,Progressive,High-grade glioma,Other high-grade glioma,Other HGG
+7316-173,Pilocytic astrocytoma,Second Malignancy,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-174,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-1744,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-1745,Low-grade glioma astrocytoma,Progressive,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-1746,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-1747,Sarcoma,Initial CNS Tumor,Mesenchymal non-meningothelial tumor,Other,Other
+7316-1748,Craniopharyngioma,Initial CNS Tumor,Tumor of sellar region,Craniopharyngioma,CRANIO
+7316-1749,Dysembryoplastic neuroepithelial tumor,Recurrence,Neuronal and mixed neuronal-glial tumor,Dysembryoplastic neuroepithelial tumor,DNET
+7316-175,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-1750,Dysembryoplastic neuroepithelial tumor,Initial CNS Tumor,Neuronal and mixed neuronal-glial tumor,Dysembryoplastic neuroepithelial tumor,DNET
+7316-1751,Craniopharyngioma,Progressive,Tumor of sellar region,Craniopharyngioma,CRANIO
+7316-1757,Neurofibroma Plexiform,Recurrence,Tumor of cranial and paraspinal nerves,Neurofibroma Plexiform,PNF
+7316-176,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-1760,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-1763,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+7316-1765,Pineoblastoma,Initial CNS Tumor,Other,Other,Other
+7316-1766,Hemangioblastoma,Progressive,Mesenchymal non-meningothelial tumor,Other,Other
+7316-1767,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-1769,Diffuse midline glioma,Progressive,High-grade glioma,Diffuse midline glioma,DMG
+7316-177,Low-grade glioma astrocytoma,Recurrence,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-1771,Atypical Teratoid Rhabdoid Tumor,Initial CNS Tumor,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,ATRT
+7316-1772,Medulloblastoma,Progressive,Embryonal tumor,Medulloblastoma,MB
+7316-1773,Craniopharyngioma,Initial CNS Tumor,Tumor of sellar region,Craniopharyngioma,CRANIO
+7316-1774,High-grade glioma astrocytoma,Progressive,High-grade glioma,Other high-grade glioma,Other HGG
+7316-1775,Craniopharyngioma,Initial CNS Tumor,Tumor of sellar region,Craniopharyngioma,CRANIO
+7316-1776,Dysembryoplastic neuroepithelial tumor,Initial CNS Tumor,Neuronal and mixed neuronal-glial tumor,Dysembryoplastic neuroepithelial tumor,DNET
+7316-1778,Atypical Teratoid Rhabdoid Tumor,Initial CNS Tumor,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,ATRT
+7316-1779,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-178,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-1781,Atypical Teratoid Rhabdoid Tumor,Initial CNS Tumor,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,ATRT
+7316-1782,Neurocytoma,Initial CNS Tumor,Neuronal and mixed neuronal-glial tumor,Other,Other
+7316-1783,Ganglioglioma,Initial CNS Tumor,Low-grade glioma,Ganglioglioma,GNG
+7316-1784,Ependymoma,Recurrence,Ependymoma,Ependymoma,EPN
+7316-1785,Germinoma,Initial CNS Tumor,Germ cell tumor,Other,Other
+7316-1786,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-1789,High-grade glioma astrocytoma,Recurrence,High-grade glioma,Other high-grade glioma,Other HGG
+7316-179,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-1790,Atypical Teratoid Rhabdoid Tumor,Progressive,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,ATRT
+7316-1792,Meningioma,Progressive,Meningioma,Meningioma,Meningioma
+7316-1793,Ganglioglioma,Initial CNS Tumor,Low-grade glioma,Ganglioglioma,GNG
+7316-1794,Pilocytic astrocytoma,Progressive,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-1795,Craniopharyngioma,Initial CNS Tumor,Tumor of sellar region,Craniopharyngioma,CRANIO
+7316-1797,Dysembryoplastic neuroepithelial tumor,Recurrence,Neuronal and mixed neuronal-glial tumor,Dysembryoplastic neuroepithelial tumor,DNET
+7316-1799,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-1801,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-1802,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-1803,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-1805,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-1806,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-1808,Meningioma,Initial CNS Tumor,Meningioma,Meningioma,Meningioma
+7316-182,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-183,Gliomatosis cerebri,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-184,Diffuse fibrillary astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-1844,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-1845,Diffuse fibrillary astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-185,Ewing sarcoma,Initial CNS Tumor,Mesenchymal non-meningothelial tumor,Ewing sarcoma,EWS
+7316-1851,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-1854,Ganglioglioma,Initial CNS Tumor,Low-grade glioma,Ganglioglioma,GNG
+7316-1855,CNS Burkitt's lymphoma,Initial CNS Tumor,Other,Other,Other
+7316-1856,Ewing sarcoma,Initial CNS Tumor,Mesenchymal non-meningothelial tumor,Ewing sarcoma,EWS
+7316-186,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-1866,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-188,Craniopharyngioma,Initial CNS Tumor,Tumor of sellar region,Craniopharyngioma,CRANIO
+7316-1884,Medulloblastoma,Progressive,Embryonal tumor,Medulloblastoma,MB
+7316-1886,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-1889,High-grade glioma astrocytoma,Progressive,High-grade glioma,Other high-grade glioma,Other HGG
+7316-189,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-1890,Desmoplastic infantile astrocytoma and ganglioglioma,Progressive,Neuronal and mixed neuronal-glial tumor,Other,Other
+7316-1893,High-grade glioma astrocytoma,Recurrence,High-grade glioma,Other high-grade glioma,Other HGG
+7316-19,Metastatic secondary tumors,Progressive,Other,Other,Other
+7316-1926,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-1927,Neuroblastoma,Progressive,Embryonal tumor,Other embryonal tumor,Other ET
+7316-1928,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-193,Diffuse fibrillary astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-1936,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+7316-1937,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+7316-194,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-1940,Ganglioglioma,Initial CNS Tumor,Low-grade glioma,Ganglioglioma,GNG
+7316-1941,Dysembryoplastic neuroepithelial tumor,Progressive,Neuronal and mixed neuronal-glial tumor,Dysembryoplastic neuroepithelial tumor,DNET
+7316-1942,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-1943,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-1944,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-1945,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-1946,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-1948,Dysembryoplastic neuroepithelial tumor,Initial CNS Tumor,Neuronal and mixed neuronal-glial tumor,Dysembryoplastic neuroepithelial tumor,DNET
+7316-1949,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-195,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+7316-1950,Craniopharyngioma,Initial CNS Tumor,Tumor of sellar region,Craniopharyngioma,CRANIO
+7316-1952,Ganglioglioma,Initial CNS Tumor,Low-grade glioma,Ganglioglioma,GNG
+7316-1953,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-1954,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-1955,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-1956,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+7316-1957,Subependymal Giant Cell Astrocytoma,Initial CNS Tumor,Low-grade glioma,Subependymal Giant Cell Astrocytoma,SEGA
+7316-1958,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-1959,Rhabdomyosarcoma,Initial CNS Tumor,Mesenchymal non-meningothelial tumor,Other,Other
+7316-196,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-1960,Adenoma,Initial CNS Tumor,Benign tumor,Other,Other
+7316-1961,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-1963,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-1965,Ganglioglioma,Initial CNS Tumor,Low-grade glioma,Ganglioglioma,GNG
+7316-1968,Rhabdomyosarcoma,Initial CNS Tumor,Mesenchymal non-meningothelial tumor,Other,Other
+7316-1969,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-197,Choroid plexus papilloma,Initial CNS Tumor,Benign tumor,Choroid plexus papilloma,CPP
+7316-1970,Dysembryoplastic neuroepithelial tumor,Initial CNS Tumor,Neuronal and mixed neuronal-glial tumor,Dysembryoplastic neuroepithelial tumor,DNET
+7316-1972,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-1975,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-1977,Subependymal Giant Cell Astrocytoma,Initial CNS Tumor,Low-grade glioma,Subependymal Giant Cell Astrocytoma,SEGA
+7316-1978,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-198,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-1981,CNS Embryonal tumor,Initial CNS Tumor,Embryonal tumor,Other embryonal tumor,Other ET
+7316-1983,Schwannoma,Initial CNS Tumor,Tumor of cranial and paraspinal nerves,Schwannoma,Schwannoma
+7316-1985,Ganglioglioma,Initial CNS Tumor,Low-grade glioma,Ganglioglioma,GNG
+7316-1986,Meningioma,Initial CNS Tumor,Meningioma,Meningioma,Meningioma
+7316-1987,Schwannoma,Initial CNS Tumor,Tumor of cranial and paraspinal nerves,Schwannoma,Schwannoma
+7316-20,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-2005,Ganglioglioma,Initial CNS Tumor,Low-grade glioma,Ganglioglioma,GNG
+7316-2006,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-2009,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-202,Ganglioneuroma,Initial CNS Tumor,Other,Other,Other
+7316-204,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-205,Craniopharyngioma,Initial CNS Tumor,Tumor of sellar region,Craniopharyngioma,CRANIO
+7316-206,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-2069,High-grade glioma astrocytoma,Recurrence,High-grade glioma,Other high-grade glioma,Other HGG
+7316-207,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-2071,Meningioma,Initial CNS Tumor,Meningioma,Meningioma,Meningioma
+7316-2075,Pleomorphic xanthoastrocytoma,Initial CNS Tumor,Low-grade glioma,Pleomorphic xanthoastrocytoma,PXA
+7316-2079,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-2084,Schwannoma,Initial CNS Tumor,Tumor of cranial and paraspinal nerves,Schwannoma,Schwannoma
+7316-2085,High-grade glioma astrocytoma,Progressive,High-grade glioma,Other high-grade glioma,Other HGG
+7316-209,Neurofibroma Plexiform,Progressive,Tumor of cranial and paraspinal nerves,Neurofibroma Plexiform,PNF
+7316-2090,Atypical Teratoid Rhabdoid Tumor,Initial CNS Tumor,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,ATRT
+7316-2091,High-grade glioma astrocytoma,Progressive,High-grade glioma,Other high-grade glioma,Other HGG
+7316-2092,High-grade glioma astrocytoma,Progressive,High-grade glioma,Other high-grade glioma,Other HGG
+7316-2099,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-2100,High-grade glioma astrocytoma,Progressive,High-grade glioma,Other high-grade glioma,Other HGG
+7316-2106,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-2107,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-2109,Ependymoma,Progressive,Ependymoma,Ependymoma,EPN
+7316-2110,Atypical Teratoid Rhabdoid Tumor,Initial CNS Tumor,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,ATRT
+7316-2118,Medulloblastoma,Progressive,Embryonal tumor,Medulloblastoma,MB
+7316-2125,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-2130,Low-grade glioma astrocytoma,Progressive,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-2133,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-2134,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-2135,Pleomorphic xanthoastrocytoma,Initial CNS Tumor,Low-grade glioma,Pleomorphic xanthoastrocytoma,PXA
+7316-2138,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-214,Meningioma,Initial CNS Tumor,Meningioma,Meningioma,Meningioma
+7316-2140,High-grade glioma astrocytoma,Progressive,High-grade glioma,Other high-grade glioma,Other HGG
+7316-2141,Atypical Teratoid Rhabdoid Tumor,Initial CNS Tumor,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,ATRT
+7316-2142,Meningioma,Second Malignancy,Meningioma,Meningioma,Meningioma
+7316-2144,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-2146,High-grade glioma astrocytoma,Progressive,High-grade glioma,Other high-grade glioma,Other HGG
+7316-2147,Low-grade glioma astrocytoma,Progressive,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-2148,Meningioma,Second Malignancy,Meningioma,Meningioma,Meningioma
+7316-2149,Germinoma,Initial CNS Tumor,Germ cell tumor,Other,Other
+7316-2150,Ewing sarcoma,Initial CNS Tumor,Mesenchymal non-meningothelial tumor,Ewing sarcoma,EWS
+7316-2151,High-grade glioma astrocytoma,Progressive,High-grade glioma,Other high-grade glioma,Other HGG
+7316-2152,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+7316-2153,Sarcoma,Initial CNS Tumor,Mesenchymal non-meningothelial tumor,Other,Other
+7316-2154,Low-grade glioma astrocytoma,Recurrence,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-2155,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-2156,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-2157,Craniopharyngioma,Initial CNS Tumor,Tumor of sellar region,Craniopharyngioma,CRANIO
+7316-2158,Craniopharyngioma,Initial CNS Tumor,Tumor of sellar region,Craniopharyngioma,CRANIO
+7316-2159,Schwannoma,Recurrence,Tumor of cranial and paraspinal nerves,Schwannoma,Schwannoma
+7316-216,Neurofibroma Plexiform,Initial CNS Tumor,Tumor of cranial and paraspinal nerves,Neurofibroma Plexiform,PNF
+7316-2166,Neurofibroma Plexiform,Progressive,Tumor of cranial and paraspinal nerves,Neurofibroma Plexiform,PNF
+7316-2167,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-2169,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-217,Low-grade glioma astrocytoma,Progressive,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-2170,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-2171,Subependymal Giant Cell Astrocytoma,Initial CNS Tumor,Low-grade glioma,Subependymal Giant Cell Astrocytoma,SEGA
+7316-2172,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-2174,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-2176,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-2177,Meningioma,Initial CNS Tumor,Meningioma,Meningioma,Meningioma
+7316-2178,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-2180,Sarcoma,Initial CNS Tumor,Mesenchymal non-meningothelial tumor,Other,Other
+7316-2181,Atypical Teratoid Rhabdoid Tumor,Initial CNS Tumor,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,ATRT
+7316-2182,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-2183,Craniopharyngioma,Initial CNS Tumor,Tumor of sellar region,Craniopharyngioma,CRANIO
+7316-2184,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-2186,Atypical Teratoid Rhabdoid Tumor,Initial CNS Tumor,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,ATRT
+7316-2187,Atypical Teratoid Rhabdoid Tumor,Initial CNS Tumor,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,ATRT
+7316-2189,High-grade glioma astrocytoma,Progressive,High-grade glioma,Other high-grade glioma,Other HGG
+7316-219,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-2191,Meningioma,Initial CNS Tumor,Meningioma,Meningioma,Meningioma
+7316-2193,Pilocytic astrocytoma,Progressive,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-2195,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-2196,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-2197,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-22,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-220,Choroid plexus papilloma,Initial CNS Tumor,Benign tumor,Choroid plexus papilloma,CPP
+7316-2202,Teratoma,Progressive,Germ cell tumor,Teratoma,Teratoma
+7316-2203,Ganglioglioma,Progressive,Low-grade glioma,Ganglioglioma,GNG
+7316-2204,Glial-neuronal tumor NOS,Initial CNS Tumor,Neuronal and mixed neuronal-glial tumor,Other,Other
+7316-2208,Diffuse leptomeningeal glioneuronal tumor,Progressive,Neuronal and mixed neuronal-glial tumor,Other,Other
+7316-221,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-2215,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-2216,Ganglioglioma,Progressive,Low-grade glioma,Ganglioglioma,GNG
+7316-2217,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-222,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-2221,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-2224,Atypical Teratoid Rhabdoid Tumor,Initial CNS Tumor,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,ATRT
+7316-2227,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-2228,Ganglioglioma,Progressive,Low-grade glioma,Ganglioglioma,GNG
+7316-223,Neurofibroma Plexiform,Initial CNS Tumor,Tumor of cranial and paraspinal nerves,Neurofibroma Plexiform,PNF
+7316-2230,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-2237,Oligodendroglioma,Recurrence,High-grade glioma,Other high-grade glioma,Other HGG
+7316-224,Neuroblastoma,Initial CNS Tumor,Embryonal tumor,Other embryonal tumor,Other ET
+7316-2240,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-2241,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-2243,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-2244,Choroid plexus papilloma,Initial CNS Tumor,Benign tumor,Choroid plexus papilloma,CPP
+7316-2245,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-2248,Choroid plexus carcinoma,Initial CNS Tumor,Other,Other,Other
+7316-2249,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-225,Metastatic secondary tumors,Initial CNS Tumor,Other,Other,Other
+7316-2250,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-2251,Choroid plexus papilloma,Initial CNS Tumor,Benign tumor,Choroid plexus papilloma,CPP
+7316-2252,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-2255,Ganglioglioma,Initial CNS Tumor,Low-grade glioma,Ganglioglioma,GNG
+7316-226,Craniopharyngioma,Initial CNS Tumor,Tumor of sellar region,Craniopharyngioma,CRANIO
+7316-2266,Ependymoma,Progressive,Ependymoma,Ependymoma,EPN
+7316-2267,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-2268,Teratoma,Initial CNS Tumor,Germ cell tumor,Teratoma,Teratoma
+7316-2269,Atypical Teratoid Rhabdoid Tumor,Initial CNS Tumor,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,ATRT
+7316-2271,Sarcoma,Recurrence,Mesenchymal non-meningothelial tumor,Other,Other
+7316-2274,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-2275,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-2276,Atypical Teratoid Rhabdoid Tumor,Progressive,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,ATRT
+7316-2278,Ependymoma,Recurrence,Ependymoma,Ependymoma,EPN
+7316-2285,Glial-neuronal tumor NOS,Recurrence,Neuronal and mixed neuronal-glial tumor,Other,Other
+7316-2287,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-2288,High-grade glioma astrocytoma,Recurrence,High-grade glioma,Other high-grade glioma,Other HGG
+7316-2291,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-23,Neuroblastoma,Recurrence,Embryonal tumor,Other embryonal tumor,Other ET
+7316-230,Ganglioglioma,Initial CNS Tumor,Low-grade glioma,Ganglioglioma,GNG
+7316-2300,Ganglioglioma,Initial CNS Tumor,Low-grade glioma,Ganglioglioma,GNG
+7316-2305,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-2306,Ganglioglioma,Initial CNS Tumor,Low-grade glioma,Ganglioglioma,GNG
+7316-2307,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-2308,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-2309,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-231,High-grade glioma astrocytoma,Progressive,High-grade glioma,Other high-grade glioma,Other HGG
+7316-2310,Pleomorphic xanthoastrocytoma,Initial CNS Tumor,Low-grade glioma,Pleomorphic xanthoastrocytoma,PXA
+7316-2311,Craniopharyngioma,Initial CNS Tumor,Tumor of sellar region,Craniopharyngioma,CRANIO
+7316-2313,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-2322,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-2324,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-2329,Neurofibroma Plexiform,Initial CNS Tumor,Tumor of cranial and paraspinal nerves,Neurofibroma Plexiform,PNF
+7316-234,Neurofibroma Plexiform,Initial CNS Tumor,Tumor of cranial and paraspinal nerves,Neurofibroma Plexiform,PNF
+7316-235,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-238,Embryonal tumor with multilayer rosettes,Progressive,Embryonal tumor,Other embryonal tumor,Other ET
+7316-240,Neurofibroma Plexiform,Initial CNS Tumor,Tumor of cranial and paraspinal nerves,Neurofibroma Plexiform,PNF
+7316-242,Meningioma,Second Malignancy,Meningioma,Meningioma,Meningioma
+7316-245,Choroid plexus papilloma,Initial CNS Tumor,Benign tumor,Choroid plexus papilloma,CPP
+7316-247,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-249,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-2536,High-grade glioma astrocytoma,Progressive,High-grade glioma,Other high-grade glioma,Other HGG
+7316-255,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-2554,High-grade glioma astrocytoma,Progressive,High-grade glioma,Other high-grade glioma,Other HGG
+7316-2556,Ependymoma,Recurrence,Ependymoma,Ependymoma,EPN
+7316-2557,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+7316-2558,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-2561,High-grade glioma astrocytoma,Recurrence,High-grade glioma,Other high-grade glioma,Other HGG
+7316-2562,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-2566,Pilocytic astrocytoma,Recurrence,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-2567,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-2569,Myxoid spindle cell tumor,Initial CNS Tumor,Other,Other,Other
+7316-257,Choroid plexus papilloma,Initial CNS Tumor,Benign tumor,Choroid plexus papilloma,CPP
+7316-2571,Ganglioglioma,Initial CNS Tumor,Low-grade glioma,Ganglioglioma,GNG
+7316-2572,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-2575,Ganglioglioma,Initial CNS Tumor,Low-grade glioma,Ganglioglioma,GNG
+7316-2576,Malignant peripheral nerve sheath tumor,Recurrence,Tumor of cranial and paraspinal nerves,Other,Other
+7316-2577,Embryonal tumor with multilayer rosettes,Recurrence,Embryonal tumor,Other embryonal tumor,Other ET
+7316-2578,Subependymal Giant Cell Astrocytoma,Initial CNS Tumor,Low-grade glioma,Subependymal Giant Cell Astrocytoma,SEGA
+7316-258,Craniopharyngioma,Initial CNS Tumor,Tumor of sellar region,Craniopharyngioma,CRANIO
+7316-2581,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-2582,Atypical Teratoid Rhabdoid Tumor,Initial CNS Tumor,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,ATRT
+7316-2583,Low-grade glioma astrocytoma,Progressive,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-2588,Meningioma,Second Malignancy,Meningioma,Meningioma,Meningioma
+7316-2589,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-259,Ganglioglioma,Initial CNS Tumor,Low-grade glioma,Ganglioglioma,GNG
+7316-2590,Neurofibroma Plexiform,Initial CNS Tumor,Tumor of cranial and paraspinal nerves,Neurofibroma Plexiform,PNF
+7316-2591,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-2594,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+7316-2599,High-grade glioma astrocytoma,Recurrence,High-grade glioma,Other high-grade glioma,Other HGG
+7316-2608,Germinoma,Initial CNS Tumor,Germ cell tumor,Other,Other
+7316-2609,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-261,Ganglioglioma,Initial CNS Tumor,Low-grade glioma,Ganglioglioma,GNG
+7316-2610,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-2614,Myofibroblastoma,Progressive,Mesenchymal non-meningothelial tumor,Other,Other
+7316-262,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-2622,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-2626,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-2628,Ganglioglioma,Initial CNS Tumor,Low-grade glioma,Ganglioglioma,GNG
+7316-263,Meningioma,Recurrence,Meningioma,Meningioma,Meningioma
+7316-2632,Pilocytic astrocytoma,Progressive,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-264,Low-grade glioma astrocytoma,Progressive,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-2640,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-2641,Juvenile xanthogranuloma,Initial CNS Tumor,Other,Other,Other
+7316-2642,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-2647,Teratoma,Progressive,Germ cell tumor,Teratoma,Teratoma
+7316-2648,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-265,Pilocytic astrocytoma,Progressive,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-2653,Langerhans Cell histiocytosis,Initial CNS Tumor,Other,Other,Other
+7316-2658,Embryonal tumor with multilayer rosettes,Initial CNS Tumor,Embryonal tumor,Other embryonal tumor,Other ET
+7316-2659,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-2660,High-grade glioma astrocytoma,Recurrence,High-grade glioma,Other high-grade glioma,Other HGG
+7316-2661,Ependymoma,Recurrence,Ependymoma,Ependymoma,EPN
+7316-2662,Germinoma,Initial CNS Tumor,Germ cell tumor,Other,Other
+7316-2663,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-2664,Pleomorphic xanthoastrocytoma,Initial CNS Tumor,Low-grade glioma,Pleomorphic xanthoastrocytoma,PXA
+7316-2665,Neurofibroma Plexiform,Initial CNS Tumor,Tumor of cranial and paraspinal nerves,Neurofibroma Plexiform,PNF
+7316-2666,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-2667,Low-grade glioma astrocytoma,Progressive,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-2668,Choroid plexus cyst,Initial CNS Tumor,Other,Other,Other
+7316-2669,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-267,Diffuse fibrillary astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-2671,Craniopharyngioma,Initial CNS Tumor,Tumor of sellar region,Craniopharyngioma,CRANIO
+7316-2672,Choroid plexus papilloma,Initial CNS Tumor,Benign tumor,Choroid plexus papilloma,CPP
+7316-2673,Meningioma,Initial CNS Tumor,Meningioma,Meningioma,Meningioma
+7316-2680,Ganglioglioma,Recurrence,Low-grade glioma,Ganglioglioma,GNG
+7316-2686,Ewing sarcoma,Initial CNS Tumor,Mesenchymal non-meningothelial tumor,Ewing sarcoma,EWS
+7316-2688,Atypical Teratoid Rhabdoid Tumor,Initial CNS Tumor,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,ATRT
+7316-2689,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-2691,Ganglioglioma,Progressive,Low-grade glioma,Ganglioglioma,GNG
+7316-2699,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-2703,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-2707,Pineoblastoma,Initial CNS Tumor,Other,Other,Other
+7316-2708,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-2719,Neurofibroma Plexiform,Initial CNS Tumor,Tumor of cranial and paraspinal nerves,Neurofibroma Plexiform,PNF
+7316-272,Embryonal tumor with multilayer rosettes,Initial CNS Tumor,Embryonal tumor,Other embryonal tumor,Other ET
+7316-2723,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-2724,Fibromyxoid lesion,Second Malignancy,Mesenchymal non-meningothelial tumor,Other,Other
+7316-2725,Pilocytic astrocytoma,Progressive,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-2729,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-2732,Meningioma,Initial CNS Tumor,Meningioma,Meningioma,Meningioma
+7316-2737,High-grade glioma astrocytoma,Progressive,High-grade glioma,Other high-grade glioma,Other HGG
+7316-2744,Low-grade glioma astrocytoma,Progressive,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-275,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-2751,High-grade glioma astrocytoma,Progressive,High-grade glioma,Other high-grade glioma,Other HGG
+7316-2752,Low-grade glioma astrocytoma,Progressive,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-2753,Low-grade glioma astrocytoma,Progressive,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-2754,Neurofibroma Plexiform,Initial CNS Tumor,Tumor of cranial and paraspinal nerves,Neurofibroma Plexiform,PNF
+7316-2755,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-2756,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+7316-2757,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-2758,Ependymoma,Progressive,Ependymoma,Ependymoma,EPN
+7316-2760,Ganglioglioma,Recurrence,Low-grade glioma,Ganglioglioma,GNG
+7316-2777,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-2779,Teratoma,Initial CNS Tumor,Germ cell tumor,Teratoma,Teratoma
+7316-278,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-2780,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-2782,Meningioma,Initial CNS Tumor,Meningioma,Meningioma,Meningioma
+7316-279,Meningioma,Progressive,Meningioma,Meningioma,Meningioma
+7316-280,Neurocytoma,Initial CNS Tumor,Neuronal and mixed neuronal-glial tumor,Other,Other
+7316-2809,Ganglioglioma,Initial CNS Tumor,Low-grade glioma,Ganglioglioma,GNG
+7316-2810,High-grade glioma astrocytoma,Progressive,High-grade glioma,Other high-grade glioma,Other HGG
+7316-2811,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-2857,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-2858,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-286,Neurofibroma Plexiform,Initial CNS Tumor,Tumor of cranial and paraspinal nerves,Neurofibroma Plexiform,PNF
+7316-2860,Choroid plexus papilloma,Initial CNS Tumor,Benign tumor,Choroid plexus papilloma,CPP
+7316-2862,Dysembryoplastic neuroepithelial tumor,Initial CNS Tumor,Neuronal and mixed neuronal-glial tumor,Dysembryoplastic neuroepithelial tumor,DNET
+7316-2864,Glial-neuronal tumor NOS,Recurrence,Neuronal and mixed neuronal-glial tumor,Other,Other
+7316-2865,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-287,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-288,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-2893,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-2897,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-2899,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-29,Schwannoma,Initial CNS Tumor,Tumor of cranial and paraspinal nerves,Schwannoma,Schwannoma
+7316-290,Subependymal Giant Cell Astrocytoma,Initial CNS Tumor,Low-grade glioma,Subependymal Giant Cell Astrocytoma,SEGA
+7316-2901,Ganglioglioma,Progressive,Low-grade glioma,Ganglioglioma,GNG
+7316-291,Schwannoma,Initial CNS Tumor,Tumor of cranial and paraspinal nerves,Schwannoma,Schwannoma
+7316-292,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-2933,Atypical Teratoid Rhabdoid Tumor,Progressive,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,ATRT
+7316-2934,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-2935,Chordoma,Progressive,Other,Other,Other
+7316-294,Sarcoma,Second Malignancy,Mesenchymal non-meningothelial tumor,Other,Other
+7316-2959,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-2961,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-2962,Diffuse fibrillary astrocytoma,Recurrence,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-2966,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-297,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-2970,High-grade glioma astrocytoma,Progressive,High-grade glioma,Other high-grade glioma,Other HGG
+7316-2971,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-2972,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-2980,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-2984,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-2986,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-2987,CNS Embryonal tumor,Initial CNS Tumor,Embryonal tumor,Other embryonal tumor,Other ET
+7316-2988,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-2989,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-2990,Pleomorphic xanthoastrocytoma,Progressive,Low-grade glioma,Pleomorphic xanthoastrocytoma,PXA
+7316-3,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-30,Schwannoma,Initial CNS Tumor,Tumor of cranial and paraspinal nerves,Schwannoma,Schwannoma
+7316-3000,High-grade glioma astrocytoma,Progressive,High-grade glioma,Other high-grade glioma,Other HGG
+7316-3010,Medulloblastoma,Progressive,Embryonal tumor,Medulloblastoma,MB
+7316-3017,Cavernoma,Initial CNS Tumor,Mesenchymal non-meningothelial tumor,Other,Other
+7316-3019,Subependymal Giant Cell Astrocytoma,Progressive,Low-grade glioma,Subependymal Giant Cell Astrocytoma,SEGA
+7316-302,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-3020,Craniopharyngioma,Initial CNS Tumor,Tumor of sellar region,Craniopharyngioma,CRANIO
+7316-3022,High-grade glioma astrocytoma,Progressive,High-grade glioma,Other high-grade glioma,Other HGG
+7316-3023,Medulloblastoma,Progressive,Embryonal tumor,Medulloblastoma,MB
+7316-3025,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-3028,Neurofibroma Plexiform,Initial CNS Tumor,Tumor of cranial and paraspinal nerves,Neurofibroma Plexiform,PNF
+7316-3029,Schwannoma,Initial CNS Tumor,Tumor of cranial and paraspinal nerves,Schwannoma,Schwannoma
+7316-3030,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-304,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-3040,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-3045,Atypical Teratoid Rhabdoid Tumor,Progressive,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,ATRT
+7316-3048,Dysembryoplastic neuroepithelial tumor,Initial CNS Tumor,Neuronal and mixed neuronal-glial tumor,Dysembryoplastic neuroepithelial tumor,DNET
+7316-305,Medulloblastoma,Recurrence,Embryonal tumor,Medulloblastoma,MB
+7316-3052,Glial-neuronal tumor NOS,Initial CNS Tumor,Neuronal and mixed neuronal-glial tumor,Other,Other
+7316-3054,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-3055,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-3057,Teratoma,Progressive,Germ cell tumor,Teratoma,Teratoma
+7316-3058,Diffuse midline glioma,Progressive,High-grade glioma,Diffuse midline glioma,DMG
+7316-306,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-3060,Ganglioglioma,Initial CNS Tumor,Low-grade glioma,Ganglioglioma,GNG
+7316-3061,Pilocytic astrocytoma,Progressive,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-3062,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-3064,Glial-neuronal tumor NOS,Initial CNS Tumor,Neuronal and mixed neuronal-glial tumor,Other,Other
+7316-3065,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-3066,Malignant peripheral nerve sheath tumor,Initial CNS Tumor,Tumor of cranial and paraspinal nerves,Other,Other
+7316-3067,Ganglioglioma,Initial CNS Tumor,Low-grade glioma,Ganglioglioma,GNG
+7316-3068,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-3069,Ependymoma,Progressive,Ependymoma,Ependymoma,EPN
+7316-307,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-3070,Craniopharyngioma,Initial CNS Tumor,Tumor of sellar region,Craniopharyngioma,CRANIO
+7316-3071,Craniopharyngioma,Recurrence,Tumor of sellar region,Craniopharyngioma,CRANIO
+7316-3072,Pineoblastoma,Initial CNS Tumor,Other,Other,Other
+7316-3074,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-3075,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-3076,Pilocytic astrocytoma,Progressive,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-309,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-310,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-312,Medulloblastoma,Recurrence,Embryonal tumor,Medulloblastoma,MB
+7316-3122,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+7316-313,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-3132,Dysembryoplastic neuroepithelial tumor,Initial CNS Tumor,Neuronal and mixed neuronal-glial tumor,Dysembryoplastic neuroepithelial tumor,DNET
+7316-3138,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-3139,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-314,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-3140,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-3147,Ganglioneuroblastoma,Recurrence,Embryonal tumor,Other embryonal tumor,Other ET
+7316-3148,Melanocytic tumor,Initial CNS Tumor,Other,Other,Other
+7316-315,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-3150,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-3153,Epilepsy,Initial CNS Tumor,Other,Other,Other
+7316-3154,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-3169,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-319,Ganglioglioma,Progressive,Low-grade glioma,Ganglioglioma,GNG
+7316-3192,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-32,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-3202,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-3203,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-3204,Choroid plexus papilloma,Initial CNS Tumor,Benign tumor,Choroid plexus papilloma,CPP
+7316-3206,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+7316-3208,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+7316-321,Ganglioglioma,Initial CNS Tumor,Low-grade glioma,Ganglioglioma,GNG
+7316-3212,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+7316-3213,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+7316-3214-A07082,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-3214-A07083,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-3215,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+7316-3216,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+7316-3217,Diffuse midline glioma,Progressive,High-grade glioma,Diffuse midline glioma,DMG
+7316-3217,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+7316-3218,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+7316-3219,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+7316-322,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-3220,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-3221,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+7316-3222,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+7316-3223,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+7316-3224,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+7316-3225,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+7316-3227,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+7316-3228,Diffuse midline glioma,Progressive,High-grade glioma,Diffuse midline glioma,DMG
+7316-3229,Diffuse midline glioma,Progressive Disease Post-Mortem,High-grade glioma,Diffuse midline glioma,DMG
+7316-323,Craniopharyngioma,Recurrence,Tumor of sellar region,Craniopharyngioma,CRANIO
+7316-3230,Diffuse midline glioma,Progressive Disease Post-Mortem,High-grade glioma,Diffuse midline glioma,DMG
+7316-3230,High-grade glioma astrocytoma,Progressive Disease Post-Mortem,High-grade glioma,Other high-grade glioma,Other HGG
+7316-3231,Diffuse midline glioma,Progressive Disease Post-Mortem,High-grade glioma,Diffuse midline glioma,DMG
+7316-3232,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-3234,Diffuse midline glioma,Progressive,High-grade glioma,Diffuse midline glioma,DMG
+7316-3235,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+7316-3237,High-grade glioma astrocytoma,Progressive Disease Post-Mortem,High-grade glioma,Other high-grade glioma,Other HGG
+7316-324,Ganglioglioma,Initial CNS Tumor,Low-grade glioma,Ganglioglioma,GNG
+7316-3240,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+7316-325,High-grade glioma astrocytoma,Recurrence,High-grade glioma,Other high-grade glioma,Other HGG
+7316-329,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-3292,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-3295,Chordoma,Recurrence,Other,Other,Other
+7316-3299,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-33,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-330,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-3300,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-3303,High-grade glioma astrocytoma,Progressive,High-grade glioma,Other high-grade glioma,Other HGG
+7316-3306,Langerhans Cell histiocytosis,Initial CNS Tumor,Other,Other,Other
+7316-3308,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-331,Meningioma,Initial CNS Tumor,Meningioma,Meningioma,Meningioma
+7316-3311,Neuroblastoma,Progressive,Embryonal tumor,Other embryonal tumor,Other ET
+7316-3312,Meningioma,Recurrence,Meningioma,Meningioma,Meningioma
+7316-3316,Craniopharyngioma,Initial CNS Tumor,Tumor of sellar region,Craniopharyngioma,CRANIO
+7316-3319,Ependymoma,Recurrence,Ependymoma,Ependymoma,EPN
+7316-332,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-3323,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-3326,Embryonal tumor with multilayer rosettes,Initial CNS Tumor,Embryonal tumor,Other embryonal tumor,Other ET
+7316-333,Medulloblastoma,Progressive,Embryonal tumor,Medulloblastoma,MB
+7316-3336,Hemangioblastoma,Initial CNS Tumor,Mesenchymal non-meningothelial tumor,Other,Other
+7316-334,Glial-neuronal tumor NOS,Initial CNS Tumor,Neuronal and mixed neuronal-glial tumor,Other,Other
+7316-3345,Ganglioglioma,Initial CNS Tumor,Low-grade glioma,Ganglioglioma,GNG
+7316-340,Neurocytoma,Progressive,Neuronal and mixed neuronal-glial tumor,Other,Other
+7316-341,Craniopharyngioma,Initial CNS Tumor,Tumor of sellar region,Craniopharyngioma,CRANIO
+7316-343,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+7316-344,Low-grade glioma astrocytoma,Progressive,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-345,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-346,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-347,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-3485,Choroid plexus papilloma,Initial CNS Tumor,Benign tumor,Choroid plexus papilloma,CPP
+7316-3488,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-349,Metastatic secondary tumors,Initial CNS Tumor,Other,Other,Other
+7316-3491,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-35,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-350,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-3504,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-3510,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-3511,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-3512,Craniopharyngioma,Initial CNS Tumor,Tumor of sellar region,Craniopharyngioma,CRANIO
+7316-3513,Craniopharyngioma,Initial CNS Tumor,Tumor of sellar region,Craniopharyngioma,CRANIO
+7316-3515,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-3516,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-3520,Dysembryoplastic neuroepithelial tumor,Initial CNS Tumor,Neuronal and mixed neuronal-glial tumor,Dysembryoplastic neuroepithelial tumor,DNET
+7316-3521,Diffuse midline glioma,Progressive,High-grade glioma,Diffuse midline glioma,DMG
+7316-3522,Pilocytic astrocytoma,Progressive,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-3554,Subependymal Giant Cell Astrocytoma,Initial CNS Tumor,Low-grade glioma,Subependymal Giant Cell Astrocytoma,SEGA
+7316-3555,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-3556,Pilocytic astrocytoma,Progressive,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-3557,Arteriovenous malformation,Recurrence,Other,Other,Other
+7316-3558,Neurofibroma Plexiform,Progressive,Tumor of cranial and paraspinal nerves,Neurofibroma Plexiform,PNF
+7316-356,Malignant peripheral nerve sheath tumor,Initial CNS Tumor,Tumor of cranial and paraspinal nerves,Other,Other
+7316-3566,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-3570,Pilocytic astrocytoma,Progressive,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-3571,Craniopharyngioma,Progressive,Tumor of sellar region,Craniopharyngioma,CRANIO
+7316-3572,Ganglioglioma,Initial CNS Tumor,Low-grade glioma,Ganglioglioma,GNG
+7316-3574,Dysembryoplastic neuroepithelial tumor,Initial CNS Tumor,Neuronal and mixed neuronal-glial tumor,Dysembryoplastic neuroepithelial tumor,DNET
+7316-3575,Pilocytic astrocytoma,Progressive,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-3576,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-358,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-359,Ganglioglioma,Initial CNS Tumor,Low-grade glioma,Ganglioglioma,GNG
+7316-361,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-362,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-3621,Dysembryoplastic neuroepithelial tumor,Initial CNS Tumor,Neuronal and mixed neuronal-glial tumor,Dysembryoplastic neuroepithelial tumor,DNET
+7316-3622,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-3623,Meningioma,Initial CNS Tumor,Meningioma,Meningioma,Meningioma
+7316-3624,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-3625,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-3626,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-3627,Low-grade glioma astrocytoma,Recurrence,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-3628,Sarcoma,Recurrence,Mesenchymal non-meningothelial tumor,Other,Other
+7316-3629,Glial-neuronal tumor NOS,Recurrence,Neuronal and mixed neuronal-glial tumor,Other,Other
+7316-3630,Glial-neuronal tumor NOS,Initial CNS Tumor,Neuronal and mixed neuronal-glial tumor,Other,Other
+7316-3631,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-3632,Chordoma,Initial CNS Tumor,Other,Other,Other
+7316-364,Ewing sarcoma,Initial CNS Tumor,Mesenchymal non-meningothelial tumor,Ewing sarcoma,EWS
+7316-365,Ependymoma,Recurrence,Ependymoma,Ependymoma,EPN
+7316-367,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-368,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-3680,Atypical Teratoid Rhabdoid Tumor,Progressive,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,ATRT
+7316-3689,CNS neuroblastoma,Initial CNS Tumor,Embryonal tumor,Other embryonal tumor,Other ET
+7316-370,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-371,High-grade glioma astrocytoma,Progressive,High-grade glioma,Other high-grade glioma,Other HGG
+7316-373,Ganglioglioma,Initial CNS Tumor,Low-grade glioma,Ganglioglioma,GNG
+7316-375,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-3751,Pilocytic astrocytoma,Progressive,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-3755,Ependymoma,Recurrence,Ependymoma,Ependymoma,EPN
+7316-3756,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-376,Atypical Teratoid Rhabdoid Tumor,Progressive,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,ATRT
+7316-3762,Pilocytic astrocytoma,Progressive,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-3765,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-3768,Dysembryoplastic neuroepithelial tumor,Initial CNS Tumor,Neuronal and mixed neuronal-glial tumor,Dysembryoplastic neuroepithelial tumor,DNET
+7316-3769,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-377,Schwannoma,Progressive,Tumor of cranial and paraspinal nerves,Schwannoma,Schwannoma
+7316-3771,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+7316-3773,Craniopharyngioma,Initial CNS Tumor,Tumor of sellar region,Craniopharyngioma,CRANIO
+7316-3774,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-3775,Ewing sarcoma,Recurrence,Mesenchymal non-meningothelial tumor,Ewing sarcoma,EWS
+7316-3776,Neurofibroma Plexiform,Progressive,Tumor of cranial and paraspinal nerves,Neurofibroma Plexiform,PNF
+7316-378,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-38,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-380,Craniopharyngioma,Initial CNS Tumor,Tumor of sellar region,Craniopharyngioma,CRANIO
+7316-3809,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-381,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-3817,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-382,Meningioma,Recurrence,Meningioma,Meningioma,Meningioma
+7316-384,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-3844,CNS neuroblastoma,Initial CNS Tumor,Embryonal tumor,Other embryonal tumor,Other ET
+7316-3846,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-3856,Pineoblastoma,Initial CNS Tumor,Other,Other,Other
+7316-3857,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-386,Atypical Teratoid Rhabdoid Tumor,Initial CNS Tumor,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,ATRT
+7316-387,Craniopharyngioma,Initial CNS Tumor,Tumor of sellar region,Craniopharyngioma,CRANIO
+7316-388,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+7316-389,Ganglioglioma,Initial CNS Tumor,Low-grade glioma,Ganglioglioma,GNG
+7316-3890,Atypical Teratoid Rhabdoid Tumor,Initial CNS Tumor,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,ATRT
+7316-3891,Craniopharyngioma,Progressive,Tumor of sellar region,Craniopharyngioma,CRANIO
+7316-3892,Mixed germ cell tumor,Progressive,Germ cell tumor,Other,Other
+7316-3893,Ependymoma,Progressive,Ependymoma,Ependymoma,EPN
+7316-39,Dysembryoplastic neuroepithelial tumor,Initial CNS Tumor,Neuronal and mixed neuronal-glial tumor,Dysembryoplastic neuroepithelial tumor,DNET
+7316-390,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-391,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-3917,Ganglioglioma,Progressive,Low-grade glioma,Ganglioglioma,GNG
+7316-3919,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-392,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+7316-3920,Atypical Teratoid Rhabdoid Tumor,Progressive,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,ATRT
+7316-3922,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-3923,Pleomorphic xanthoastrocytoma,Recurrence,Low-grade glioma,Pleomorphic xanthoastrocytoma,PXA
+7316-393,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-3935,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+7316-3936,Dysembryoplastic neuroepithelial tumor,Initial CNS Tumor,Neuronal and mixed neuronal-glial tumor,Dysembryoplastic neuroepithelial tumor,DNET
+7316-3937,Atypical Teratoid Rhabdoid Tumor,Initial CNS Tumor,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,ATRT
+7316-394,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-395,Ganglioglioma,Initial CNS Tumor,Low-grade glioma,Ganglioglioma,GNG
+7316-3963,Schwannoma,Progressive,Tumor of cranial and paraspinal nerves,Schwannoma,Schwannoma
+7316-397,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-398,Neurofibroma Plexiform,Initial CNS Tumor,Tumor of cranial and paraspinal nerves,Neurofibroma Plexiform,PNF
+7316-399,Low-grade glioma astrocytoma,Progressive,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-400,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-4028,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-4033,Ganglioneuroblastoma,Initial CNS Tumor,Embryonal tumor,Other embryonal tumor,Other ET
+7316-4034,Ganglioneuroblastoma,Initial CNS Tumor,Embryonal tumor,Other embryonal tumor,Other ET
+7316-4035,Ependymoma,Recurrence,Ependymoma,Ependymoma,EPN
+7316-405,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-406,Choroid plexus carcinoma,Initial CNS Tumor,Other,Other,Other
+7316-4062,Chordoma,Progressive,Other,Other,Other
+7316-407,Medulloblastoma,Progressive,Embryonal tumor,Medulloblastoma,MB
+7316-408,Teratoma,Progressive,Germ cell tumor,Teratoma,Teratoma
+7316-409,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+7316-41,Atypical Teratoid Rhabdoid Tumor,Initial CNS Tumor,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,ATRT
+7316-423,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-425,Ependymoma,Progressive,Ependymoma,Ependymoma,EPN
+7316-429,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-430,High-grade glioma astrocytoma,Recurrence,High-grade glioma,Other high-grade glioma,Other HGG
+7316-431,Choroid plexus carcinoma,Initial CNS Tumor,Other,Other,Other
+7316-4341,Schwannoma,Initial CNS Tumor,Tumor of cranial and paraspinal nerves,Schwannoma,Schwannoma
+7316-435,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-436,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-437,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-438,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-440,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-441,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-442,Low-grade glioma astrocytoma,Recurrence,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-443,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-4446,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+7316-4447,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-4448,Diffuse midline glioma,Progressive,High-grade glioma,Diffuse midline glioma,DMG
+7316-445,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-447,Embryonal tumor with multilayer rosettes,Progressive,Embryonal tumor,Other embryonal tumor,Other ET
+7316-448,Schwannoma,Initial CNS Tumor,Tumor of cranial and paraspinal nerves,Schwannoma,Schwannoma
+7316-449,Low-grade glioma astrocytoma,Progressive,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-451,Ependymoma,Recurrence,Ependymoma,Ependymoma,EPN
+7316-452,Ganglioglioma,Progressive,Low-grade glioma,Ganglioglioma,GNG
+7316-454,Ependymoma,Progressive,Ependymoma,Ependymoma,EPN
+7316-455,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-456,Schwannoma,Initial CNS Tumor,Tumor of cranial and paraspinal nerves,Schwannoma,Schwannoma
+7316-458,Ewing sarcoma,Initial CNS Tumor,Mesenchymal non-meningothelial tumor,Ewing sarcoma,EWS
+7316-459,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-46,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+7316-460,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-461,Diffuse midline glioma,Progressive,High-grade glioma,Diffuse midline glioma,DMG
+7316-462,Low-grade glioma astrocytoma,Recurrence,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-464,CNS Embryonal tumor,Initial CNS Tumor,Embryonal tumor,Other embryonal tumor,Other ET
+7316-466,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+7316-467,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-47,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-470,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-471,Choroid plexus papilloma,Initial CNS Tumor,Benign tumor,Choroid plexus papilloma,CPP
+7316-472,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-475,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-476,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-477,Meningioma,Recurrence,Meningioma,Meningioma,Meningioma
+7316-479,Atypical Teratoid Rhabdoid Tumor,Initial CNS Tumor,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,ATRT
+7316-480,Dysembryoplastic neuroepithelial tumor,Initial CNS Tumor,Neuronal and mixed neuronal-glial tumor,Dysembryoplastic neuroepithelial tumor,DNET
+7316-482,Pilocytic astrocytoma,Progressive,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-485,Low-grade glioma astrocytoma,Progressive,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-487,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-488,Pilocytic astrocytoma,Progressive,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-489,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-490,Ependymoma,Progressive,Ependymoma,Ependymoma,EPN
+7316-493,Langerhans Cell histiocytosis,Initial CNS Tumor,Other,Other,Other
+7316-495,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-496,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-497,Neurofibroma Plexiform,Second Malignancy,Tumor of cranial and paraspinal nerves,Neurofibroma Plexiform,PNF
+7316-499,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-4998,Diffuse intrinsic pontine glioma,Initial CNS Tumor,High-grade glioma,Diffuse intrinsic pontine glioma,DIPG
+7316-5,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-50,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-502,Desmoplastic infantile astrocytoma and ganglioglioma,Progressive,Neuronal and mixed neuronal-glial tumor,Other,Other
+7316-505,CNS Embryonal tumor,Progressive,Embryonal tumor,Other embryonal tumor,Other ET
+7316-506,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-51,Dysembryoplastic neuroepithelial tumor,Progressive,Neuronal and mixed neuronal-glial tumor,Dysembryoplastic neuroepithelial tumor,DNET
+7316-512,CNS Embryonal tumor,Initial CNS Tumor,Embryonal tumor,Other embryonal tumor,Other ET
+7316-515,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-516,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-519,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-521,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-523,Meningioma,Initial CNS Tumor,Meningioma,Meningioma,Meningioma
+7316-525,Atypical Teratoid Rhabdoid Tumor,Initial CNS Tumor,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,ATRT
+7316-529,CNS Embryonal tumor,Progressive,Embryonal tumor,Other embryonal tumor,Other ET
+7316-532,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-535,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-536,CNS Embryonal tumor,Initial CNS Tumor,Embryonal tumor,Other embryonal tumor,Other ET
+7316-544,Diffuse intrinsic pontine glioma,Progressive,High-grade glioma,Diffuse intrinsic pontine glioma,DIPG
+7316-545,Diffuse intrinsic pontine glioma,Progressive,High-grade glioma,Diffuse intrinsic pontine glioma,DIPG
+7316-548,Diffuse intrinsic pontine glioma,Progressive,High-grade glioma,Diffuse intrinsic pontine glioma,DIPG
+7316-549,Diffuse intrinsic pontine glioma,Progressive,High-grade glioma,Diffuse intrinsic pontine glioma,DIPG
+7316-550,Diffuse intrinsic pontine glioma,Progressive,High-grade glioma,Diffuse intrinsic pontine glioma,DIPG
+7316-553,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-554,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-556,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-561,Craniopharyngioma,Initial CNS Tumor,Tumor of sellar region,Craniopharyngioma,CRANIO
+7316-562,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-6,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-612,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-619,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-620,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-622,High-grade glioma astrocytoma,Recurrence,High-grade glioma,Other high-grade glioma,Other HGG
+7316-624,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-639,Diffuse intrinsic pontine glioma,Initial CNS Tumor,High-grade glioma,Diffuse intrinsic pontine glioma,DIPG
+7316-641,Schwannoma,Initial CNS Tumor,Tumor of cranial and paraspinal nerves,Schwannoma,Schwannoma
+7316-642,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-643,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-644,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+7316-658,Pilocytic astrocytoma,Progressive,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-659,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-663,Subependymal Giant Cell Astrocytoma,Initial CNS Tumor,Low-grade glioma,Subependymal Giant Cell Astrocytoma,SEGA
+7316-666,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-670,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-676,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-677,Subependymal Giant Cell Astrocytoma,Initial CNS Tumor,Low-grade glioma,Subependymal Giant Cell Astrocytoma,SEGA
+7316-681,Desmoplastic infantile astrocytoma and ganglioglioma,Initial CNS Tumor,Neuronal and mixed neuronal-glial tumor,Other,Other
+7316-692,Pleomorphic xanthoastrocytoma,Initial CNS Tumor,Low-grade glioma,Pleomorphic xanthoastrocytoma,PXA
+7316-70,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-71,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-714,High-grade glioma astrocytoma,Recurrence,High-grade glioma,Other high-grade glioma,Other HGG
+7316-715,Diffuse intrinsic pontine glioma,Initial CNS Tumor,High-grade glioma,Diffuse intrinsic pontine glioma,DIPG
+7316-716,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-719,Diffuse intrinsic pontine glioma,Progressive,High-grade glioma,Diffuse intrinsic pontine glioma,DIPG
+7316-723,Choroid plexus carcinoma,Initial CNS Tumor,Other,Other,Other
+7316-725,Atypical choroid plexus papilloma,Progressive,Benign tumor,Other,Other
+7316-726,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-727,Meningioma,Initial CNS Tumor,Meningioma,Meningioma,Meningioma
+7316-729,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-73,Langerhans Cell histiocytosis,Initial CNS Tumor,Other,Other,Other
+7316-733,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-735,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-736,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-737,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-739,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-740,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-741,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-746,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-747,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-749,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-76,Metastatic secondary tumors,Initial CNS Tumor,Other,Other,Other
+7316-762,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-764,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-765,CNS Embryonal tumor,Initial CNS Tumor,Embryonal tumor,Other embryonal tumor,Other ET
+7316-77,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-775,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-784,Embryonal tumor with multilayer rosettes,Initial CNS Tumor,Embryonal tumor,Other embryonal tumor,Other ET
+7316-80,Dysembryoplastic neuroepithelial tumor,Initial CNS Tumor,Neuronal and mixed neuronal-glial tumor,Dysembryoplastic neuroepithelial tumor,DNET
+7316-820,Atypical Teratoid Rhabdoid Tumor,Initial CNS Tumor,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,ATRT
+7316-839,Medulloblastoma,Progressive,Embryonal tumor,Medulloblastoma,MB
+7316-84,Diffuse fibrillary astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-842,Medulloblastoma,Recurrence,Embryonal tumor,Medulloblastoma,MB
+7316-843,Medulloblastoma,Recurrence,Embryonal tumor,Medulloblastoma,MB
+7316-85,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+7316-851,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-853,Choroid plexus papilloma,Initial CNS Tumor,Benign tumor,Choroid plexus papilloma,CPP
+7316-869,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-87,CNS Embryonal tumor,Initial CNS Tumor,Embryonal tumor,Other embryonal tumor,Other ET
+7316-870,High-grade glioma astrocytoma,Progressive,High-grade glioma,Other high-grade glioma,Other HGG
+7316-871,CNS Embryonal tumor,Initial CNS Tumor,Embryonal tumor,Other embryonal tumor,Other ET
+7316-872,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-873,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-874,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-875,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-876,Ewing sarcoma,Initial CNS Tumor,Mesenchymal non-meningothelial tumor,Ewing sarcoma,EWS
+7316-877,Meningioma,Progressive,Meningioma,Meningioma,Meningioma
+7316-878,Atypical Teratoid Rhabdoid Tumor,Initial CNS Tumor,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,ATRT
+7316-88,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-880,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-882,Pilocytic astrocytoma,Progressive,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-883,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-884,Pleomorphic xanthoastrocytoma,Initial CNS Tumor,Low-grade glioma,Pleomorphic xanthoastrocytoma,PXA
+7316-889,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-89,High-grade glioma astrocytoma,Progressive,High-grade glioma,Other high-grade glioma,Other HGG
+7316-891,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-892,Ependymoma,Progressive,Ependymoma,Ependymoma,EPN
+7316-893,Ganglioglioma,Recurrence,Low-grade glioma,Ganglioglioma,GNG
+7316-894,Teratoma,Initial CNS Tumor,Germ cell tumor,Teratoma,Teratoma
+7316-895,High-grade glioma astrocytoma,Recurrence,High-grade glioma,Other high-grade glioma,Other HGG
+7316-896,Pilocytic astrocytoma,Recurrence,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-897,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-898,Low-grade glioma astrocytoma,Progressive,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-9,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-901,Meningioma,Second Malignancy,Meningioma,Meningioma,Meningioma
+7316-903,Diffuse midline glioma,Recurrence,High-grade glioma,Diffuse midline glioma,DMG
+7316-905,Ganglioglioma,Initial CNS Tumor,Low-grade glioma,Ganglioglioma,GNG
+7316-906,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-908,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-91,Ganglioglioma,Initial CNS Tumor,Low-grade glioma,Ganglioglioma,GNG
+7316-913,High-grade glioma astrocytoma,Second Malignancy,High-grade glioma,Other high-grade glioma,Other HGG
+7316-914,Ganglioglioma,Initial CNS Tumor,Low-grade glioma,Ganglioglioma,GNG
+7316-915,Dysembryoplastic neuroepithelial tumor,Initial CNS Tumor,Neuronal and mixed neuronal-glial tumor,Dysembryoplastic neuroepithelial tumor,DNET
+7316-917,Pilocytic astrocytoma,Progressive,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-918,Atypical Teratoid Rhabdoid Tumor,Initial CNS Tumor,Embryonal tumor,Atypical Teratoid Rhabdoid Tumor,ATRT
+7316-92,Cavernoma,Initial CNS Tumor,Mesenchymal non-meningothelial tumor,Other,Other
+7316-921,Chordoma,Initial CNS Tumor,Other,Other,Other
+7316-922,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-923,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-924,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-925,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-929,Ependymoma,Recurrence,Ependymoma,Ependymoma,EPN
+7316-93,Low-grade glioma astrocytoma,Progressive,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-931,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-932,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-934,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-935,Neurofibroma Plexiform,Second Malignancy,Tumor of cranial and paraspinal nerves,Neurofibroma Plexiform,PNF
+7316-936,Subependymal Giant Cell Astrocytoma,Initial CNS Tumor,Low-grade glioma,Subependymal Giant Cell Astrocytoma,SEGA
+7316-937,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-938,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-94,Meningioma,Initial CNS Tumor,Meningioma,Meningioma,Meningioma
+7316-944,Low-grade glioma astrocytoma,Recurrence,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-946,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-948,Schwannoma,Initial CNS Tumor,Tumor of cranial and paraspinal nerves,Schwannoma,Schwannoma
+7316-949,Craniopharyngioma,Recurrence,Tumor of sellar region,Craniopharyngioma,CRANIO
+7316-95,Medulloblastoma,Progressive,Embryonal tumor,Medulloblastoma,MB
+7316-950,CNS Embryonal tumor,Progressive,Embryonal tumor,Other embryonal tumor,Other ET
+7316-952,Dysembryoplastic neuroepithelial tumor,Initial CNS Tumor,Neuronal and mixed neuronal-glial tumor,Dysembryoplastic neuroepithelial tumor,DNET
+7316-954,Pilocytic astrocytoma,Initial CNS Tumor,Low-grade glioma,Pilocytic astrocytoma,PA
+7316-956,Ewing sarcoma,Progressive,Mesenchymal non-meningothelial tumor,Ewing sarcoma,EWS
+7316-957,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+7316-96,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-965,Teratoma,Initial CNS Tumor,Germ cell tumor,Teratoma,Teratoma
+7316-966,Ependymoma,Initial CNS Tumor,Ependymoma,Ependymoma,EPN
+7316-968,Medulloblastoma,Initial CNS Tumor,Embryonal tumor,Medulloblastoma,MB
+7316-97,Pleomorphic xanthoastrocytoma,Initial CNS Tumor,Low-grade glioma,Pleomorphic xanthoastrocytoma,PXA
+7316-974,Low-grade glioma astrocytoma,Initial CNS Tumor,Low-grade glioma,Other low-grade glioma,Other LGG
+A03942,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+A05262,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+A07082,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+A07150,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+A08692,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+A08732,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+A08768,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+A08958,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+A09410,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+A09446,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+A09576,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+A09689,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+A09985,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+A12398,Diffuse midline glioma,Progressive,High-grade glioma,Diffuse midline glioma,DMG
+A12748,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+A12911,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+A14449,Diffuse midline glioma,Progressive,High-grade glioma,Diffuse midline glioma,DMG
+A14565,High-grade glioma astrocytoma,Initial CNS Tumor,High-grade glioma,Other high-grade glioma,Other HGG
+A14567,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+A14709,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+A15170,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+A15726,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+A16405,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+A16538,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+A16915,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+A17096,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+A17997,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+A18552,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+A18777,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+A19015,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+A19649,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG
+A20091,Diffuse midline glioma,Initial CNS Tumor,High-grade glioma,Diffuse midline glioma,DMG


### PR DESCRIPTION
While working to update panel 1B as part of #1736, I saw that the Zenodo table export was rather wrong. A column with `\n` snuck in, so the previous CSV export was in fact not a properly formatted CSV. I removed that column, as well as a couple other columns that can be purged.