### PR TITLE
Update debian sources list 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ COPY scripts/install_bioc.r .
 
 ### Install apt-getable packages to start
 #########################################
+
+# stretch is EOL, so we need to use the archive
+RUN echo "deb http://archive.debian.org/debian stretch main" > /etc/apt/sources.list
 RUN apt-get update && apt-get install -y --no-install-recommends apt-utils dialog
 
 # Add curl, bzip2 and some dev libs


### PR DESCRIPTION
Looks like Debian finally pulled the plug on Debian 9 (Stretch) so now we have to deal with that. This is a first attempt, but it is failing locally when trying to build java, so we'll see. 