### PR TITLE
Add note about publication, no longer accepting contributions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # OpenPBTA-analysis
 
+---
+
+**OpenPBTA is now published**:
+
+Shapiro, J.A., Gaonkar, K.S., Spielman, S.J., Savonen, C.L., Bethell, C.J., Jin, R., Rathi, K.S., Zhu, Y., Egolf, L.E., Farrow, B.K., et al. (2023). OpenPBTA: The Open Pediatric Brain Tumor Atlas. Cell Genom., 100340. [10.1016/j.xgen.2023.100340](https://doi.org/10.1016/j.xgen.2023.100340).
+
+**We will no longer be accepting contributions to this repository.**
+
+Please check out [`d3b-center/OpenPedCan-analysis`](https://github.com/d3b-center/OpenPedCan-analysis) for updates to PBTA data as well as other data sources.
+
+---
+
 Pediatric brain tumors are the most common solid tumors and the leading cause of cancer-related death in children.
 Our ability to understand and successfully treat these diseases is hindered by small sample sizes due to the overall rarity of unique molecular subtypes and tainted grouped analyses resulting from misclassification.
 In September of 2018, the [Children's Brain Tumor Network (CBTN)](https://cbtn.org/) released the [Pediatric Brain Tumor Atlas (PBTA)](https://cbtn.org/pediatric-brain-tumor-atlas/), a genomic dataset (whole genome sequencing, whole exome sequencing, RNA sequencing, proteomic, and clinical data) for nearly 1,000 tumors, available from the [Gabriella Miller Kids First Portal](https://kidsfirstdrc.org/).


### PR DESCRIPTION
Related to: #1760 

I've added text to the top of the README with the publication (citation uses _Cell Genomics_ style), a note that we will no longer accept contributions, and a pointer to OpenPedCan. I will port whatever gets merged here over to the manuscript repo README.